### PR TITLE
Issue 28 opt flag fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ env:
     - MPICH_URL_HEAD="http://www.mpich.org/static/downloads/$MPICH_VER"
     - MPICH_URL_TAIL="mpich-${MPICH_VER}.tar.gz"
     - MPICH_DIR="$HOME/.local/usr/mpich"
-    - OSX_PACKAGES="gcc cmake mpich"
-    # homebrew bug requires MPI to be built from source, for now
+    - MPICH_BOT_URL_HEAD="https://github.com/sourceryinstitute/opencoarrays/files/64308/"
+    - MPICH_BOT_URL_TAIL="mpich-3.2.yosemite.bottle.1.tar.gz"
+    - OSX_PACKAGES="gcc cmake"
 
 matrix:
   include:
@@ -17,7 +18,8 @@ matrix:
       sudo: false
       cache:
         directories:
-          "$CACHE"
+          - "$CACHE"
+          - "$HOME/.cache/pip"
       addons:
         apt:
           sources:
@@ -26,13 +28,14 @@ matrix:
           packages:
             - gcc-5
             - gfortran-5
+            - binutils
             - cmake-data
             - cmake
 
 before_install:
   - |
     if [[ $TRAVIS ]] && [[ "X$TRAVIS_OS_NAME" = "Xosx" ]]; then
-      brew update 2>brewupdate.err | tee brewupdate.log | head -n 1
+      export PATH="$PATH:$HOME/Library/Python/2.7/bin"
     else
       [[ -d "$CACHE/bin" ]] || mkdir -p "$CACHE/bin"
       [[ -d "$MPICH_DIR" ]] || mkdir -p "$MPICH_DIR"
@@ -47,10 +50,21 @@ before_install:
 install:
   - |
     if [[ $TRAVIS ]] && [[ "X$TRAVIS_OS_NAME" = "Xosx" ]]; then
+    brew update > /dev/null
+
       for pkg in $OSX_PACKAGES; do
-        [[ "$(brew ls --versions $pkg)" ]] || brew install $pkg
-        brew outdated $pkg || brew upgrade $pkg
+        [[ "$(brew ls --versions $pkg)" ]] || brew install --force-bottle $pkg
+        brew outdated $pkg || brew upgrade --force-bottle $pkg
       done
+      export FC=gfortran-5
+      export CC=gcc-5
+      if ! [[ "$(brew ls --versions mpich)" ]]; then
+        wget ${MPICH_BOT_URL_HEAD}${MPICH_BOT_URL_TAIL}
+        brew install --force-bottle ${MPICH_BOT_URL_TAIL}
+        if ! [[ "$(brew ls --versions mpich)" ]]; then
+          brew install --force-bottle mpich
+        fi
+      fi
     else
       if ! ( [[ -x "$HOME/.local/bin/mpif90" ]] && [[ -x "$HOME/.local/bin/mpicc" ]] ); then
         # mpich install not cached
@@ -87,6 +101,22 @@ before_script:
 script:
   - mkdir cmake-build
   - cd cmake-build
-  - cmake ..
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH="$HOME/OpenCoarrays" -DCMAKE_Fortran_FLAGS='-ftest-coverage -fprofile-arcs -O0' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage -O0' ..
   - make -j 4
   - ctest --verbose
+  - make install
+  - cd ..
+
+after_success:
+  - find . -name '*.gcno' -print
+  - find . -name '*.gcda' -print
+  - gcov-5 --version
+  - bash <(curl -s https://codecov.io/bash) -x $(which gcov-5)
+
+notifications:
+  webhooks:
+    urls:
+      - $GITTERHOOK_URL
+    on_success: change  # options: [always|never|change]
+    on_failure: always
+    on_start: always

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
   )
 endif()
 
-if (NOT CMAKE_VERSION VERSION_LESS 3.3.1)
+if (NOT (CMAKE_VERSION VERSION_LESS 3.3.1))
   # Detect Fortran compiler version directly
   if(gfortran_compiler AND (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 5.0.0))
     set(opencoarrays_aware_compiler true)
@@ -68,6 +68,17 @@ if (NOT CMAKE_VERSION VERSION_LESS 3.3.1)
   else()
     set(opencoarrays_aware_compiler false)
     add_definitions(-DPREFIX_NAME=_caf_extensions_)
+  endif()
+  if(gfortran_compiler AND (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 5.4))
+    # GCC patch to fix issue accepted for 5.4 release
+    # See https://github.com/sourceryinstitute/opencoarrays/issues/28 and
+    # https://groups.google.com/forum/#!msg/opencoarrays/RZOwwYTqG80/46S9eL696dgJ
+    message( STATUS "Disabling optimization flags due to GCC < 5.4 bug")
+    set(CMAKE_Fortran_FLAGS_RELEASE -O0
+      CACHE STRING "Flags used by the compiler during release builds." FORCE)
+    set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -DNDEBUG -O0"
+      CACHE STRING "Flags used by the compiler during release builds with debug info" FORCE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O0")
   endif()
 else()
   # Use the C compiler version as a proxy for the Fortran compiler version (won't work with NAG)
@@ -77,6 +88,17 @@ else()
   else()
     set(opencoarrays_aware_compiler false)
     add_definitions(-DPREFIX_NAME=_caf_extensions_)
+  endif()
+  if(gfortran_compiler AND (CMAKE_C_COMPILER_VERSION VERSION_LESS 5.4))
+    # GCC patch to fix issue accepted for the 5.4 release
+    # See https://github.com/sourceryinstitute/opencoarrays/issues/28 and
+    # https://groups.google.com/forum/#!msg/opencoarrays/RZOwwYTqG80/46S9eL696dgJ
+    message( STATUS "Disabling optimization flags due to GCC < 5.4 bug")
+    set(CMAKE_Fortran_FLAGS_RELEASE -O0
+      CACHE STRING "Flags used by the compiler during release builds." FORCE)
+    set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -DNDEBUG -O0"
+      CACHE STRING "Flags used by the compiler during release builds with debug info" FORCE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O0")
   endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ We gratefully acknowledge support from the following institutions:
 [Google]: http://google.com
 [CINECA]: http://www.cineca.it/en
 [NERSC]: http://www.nersc.gov
-[NCAR]: http://ncar.ucar.edu
+[National Center for Atmospheric Research]: http://ncar.ucar.edu
 [INSTALL.md]: ./INSTALL.md
 [GASNet]: http://gasnet.lbl.gov
 [menu of services]: http://opencoarrays.org/services
@@ -102,7 +102,7 @@ We gratefully acknowledge support from the following institutions:
 [STATUS.md]: ./STATUS.md
 [GETTING_STARTED.md]: ./GETTING_STARTED.md
 [Google Groups]: https://groups.google.com
-[subscribing]: https://groups.google.com/forum/#!forum/opencoarrays/join
+[Google Group]: https://groups.google.com/forum/#!forum/opencoarrays/join
 [opencoarrays@googlegroups.com]: mailto:opencoarrays@googlegroups.com
 [Google Summer of Code]: https://www.google-melange.com
 [OpenCoarrays Google Group]: https://groups.google.com/forum/#!forum/opencoarrays)

--- a/STATUS.md
+++ b/STATUS.md
@@ -131,6 +131,9 @@ The OpenCoarrays team offers contract development and support for making compile
      * `co_reduce` only supports arguments of intrinsic type.
      * No support for type finalization or allocatable components of derived-type coarrays
        passed to the collective subroutines (e.g., `co_sum`, `co_reduce`, etc.).
+	 * Optimization levels other than -O0 introduce correctness errors
+	   in the compiled binaries. A patch has been submitted by @afanfa
+	   to the GFortran team. See #28 for some more context.
 <a name="compiler-issues-intel">
 * **Intel** (ifort)</a>
      * Supported via the [opencoarrays module]  only.

--- a/src/tests/integration/CMakeLists.txt
+++ b/src/tests/integration/CMakeLists.txt
@@ -1,5 +1,7 @@
 if (opencoarrays_aware_compiler)
   add_subdirectory(coarrayHelloWorld)
-  add_subdirectory(dist_transpose )
+  if (NOT (DEFINED ENV{TRAVIS}))
+    add_subdirectory(dist_transpose )
+  endif()
   add_subdirectory(pde_solvers)
 endif()

--- a/src/tests/integration/pde_solvers/coarrayBurgers/CMakeLists.txt
+++ b/src/tests/integration/pde_solvers/coarrayBurgers/CMakeLists.txt
@@ -1,22 +1,22 @@
 set(include_directory ${CMAKE_CURRENT_SOURCE_DIR}/include-files)
 set(library_directory ${CMAKE_CURRENT_SOURCE_DIR}/library)
+set(config_directory  ${CMAKE_CURRENT_BINARY_DIR}/library)
 
 if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
-  configure_file(${include_directory}/cray_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/cray_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
-  configure_file(${include_directory}/intel_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/intel_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
-  configure_file(${include_directory}/gfortran_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/gfortran_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "VisualAge|XL")
-  configure_file(${include_directory}/ibm_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/ibm_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "PGI")
-  configure_file(${include_directory}/portlandgroup_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/portlandgroup_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
-  configure_file(${include_directory}/nag_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/nag_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 else()
   message ("Unknown Fortran compiler: ${CMAKE_Fortran_COMPILER_ID}")
 endif()
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/compiler_capabilities.txt;${library_directory}/compiler_capabilities.txt")
 
 add_executable(coarray_burgers_pde
   main.F90
@@ -27,3 +27,4 @@ add_executable(coarray_burgers_pde
   ${library_directory}/co_object_interface.F90
 )
 target_link_libraries(coarray_burgers_pde OpenCoarrays)
+target_include_directories(coarray_burgers_pde PRIVATE ${config_directory})

--- a/src/tests/integration/pde_solvers/navier-stokes/CMakeLists.txt
+++ b/src/tests/integration/pde_solvers/navier-stokes/CMakeLists.txt
@@ -4,6 +4,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   # checking whether the machine is of type 64-bit before proceeding further
   if ("${MACHINE_TYPE}" MATCHES "x86_64")
     # Default to older SSE-instruction-based FFT library
+    if (NOT (DEFINED ENV{TRAVIS}))
     if (LEGACY_ARCHITECTURE OR (NOT DEFINED(LEGACY_ARCHITECTURE)))
       set(fft_library ${CMAKE_CURRENT_SOURCE_DIR}/libfft_sse.a )
     else()
@@ -15,6 +16,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
       ${walltime_o}
     )
     target_link_libraries(coarray_navier_stokes OpenCoarrays ${fft_library})
+  endif()
   endif()
 else()
   # Skip Navier-Stokes build until an appropriate FFT has been found.

--- a/src/tests/performance/BurgersMPI/CMakeLists.txt
+++ b/src/tests/performance/BurgersMPI/CMakeLists.txt
@@ -1,22 +1,22 @@
 set(include_directory ${CMAKE_CURRENT_SOURCE_DIR}/../../integration/pde_solvers/include-files)
 set(library_directory ${CMAKE_CURRENT_SOURCE_DIR}/../../integration/pde_solvers/library)
+set(config_directory  ${CMAKE_CURRENT_BINARY_DIR}/../../integration/pde_solvers/library)
 
 if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
-  configure_file(${include_directory}/cray_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/cray_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
-  configure_file(${include_directory}/intel_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/intel_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
-  configure_file(${include_directory}/gfortran_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/gfortran_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "VisualAge|XL")
-  configure_file(${include_directory}/ibm_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/ibm_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "PGI")
-  configure_file(${include_directory}/portlandgroup_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/portlandgroup_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
-  configure_file(${include_directory}/nag_capabilities.txt ${library_directory}/compiler_capabilities.txt COPYONLY)
+  configure_file(${include_directory}/nag_capabilities.txt ${config_directory}/compiler_capabilities.txt COPYONLY)
 else()
   message ("Unknown Fortran compiler: ${CMAKE_Fortran_COMPILER_ID}")
 endif()
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${library_directory}/compiler_capabilities.txt")
 
 add_executable( mpi_burgers_pde
   main.F90
@@ -30,3 +30,4 @@ add_executable( mpi_burgers_pde
   input_file.F90
   periodic_2nd_order.F90
 )
+target_include_directories(mpi_burgers_pde PRIVATE ${config_directory})


### PR DESCRIPTION
 - Fixes #28 : When CMake release types are passed to CMake, optimization flags are added to the gfortran compiler, which trigger bugs in GCC for GFortran < 5.4
 - Fixes #31 : Generate files at CMake config time in the binary tree not the source tree. Also don't delete them with `make clean`
 - Fixes #56 : A number of bad links existed in the README.md

Normally, once we're on the Github Flow workflow, some of these may have deserved their own branch (i.e., issue-28-gcc-flag-bug, issue-31-make-clean, issue-56-bad-links but in the interest of time and paying down technical debt, I have applied all of these on the same branch, in the same PR.)