### PR TITLE
Apply clearer CMake version checking from master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,7 @@ else()
   )
 endif()
 
-
-if (CMAKE_VERSION VERSION_GREATER 3.2.3)
+if (NOT (CMAKE_VERSION VERSION_LESS 3.3.1))
   # Detect Fortran compiler version directly
   if(gfortran_compiler AND (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 5.0.0))
     set(opencoarrays_aware_compiler true)

--- a/src/tests/unit/extensions/CMakeLists.txt
+++ b/src/tests/unit/extensions/CMakeLists.txt
@@ -2,7 +2,7 @@ if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
   set(gfortran_compiler true)
 endif()
 
-if (CMAKE_VERSION VERSION_GREATER 3.2.3)
+if (NOT CMAKE_VERSION VERSION_LESS 3.3.1)
   # Detect Fortran compiler version directly
   if(gfortran_compiler AND (NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 5.2))
     set(opencoarrays_aware_compiler true)


### PR DESCRIPTION
Brings branch 1.x closer to master, and applies, at least IMO, clearer CMake version checking logic.