### PR TITLE
Eliminated need for sudo install.sh or sudo build

### DIFF
--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -149,7 +149,6 @@ else
   num_threads=$4
 fi
 
-
 check_prerequisites()
 {
   # This is a bash 3 hack standing in for a bash 4 hash (bash 3 is the lowest common
@@ -336,6 +335,8 @@ unpack_if_necessary()
   fi
 }
 
+. ./set_SUDO.sh
+
 # Make the build directory, configure, and build
 build_and_install()
 {
@@ -344,6 +345,7 @@ build_and_install()
   printf "Building $package_to_build $version_to_build.\n" &&
   mkdir -p $build_path &&
   pushd $build_path &&
+  set_SUDO_if_necessary &&
   if [[ $package_to_build == "gcc" ]]; then
     pushd $download_path/$package_source_directory &&
     ${PWD}/contrib/download_prerequisites &&
@@ -351,13 +353,26 @@ build_and_install()
     echo "Configuring with the following command: " &&
     echo "$download_path/$package_source_directory/configure  --prefix=$install_path --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror " &&
     $download_path/$package_source_directory/configure --prefix=$install_path --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror &&
+    echo "Building with the commmand 'make -j $num_threads bootstrap'" &&
     make -j $num_threads bootstrap &&
-    make install
+    if [[ ! -z $SUDO ]]; then
+      echo "You do not have write permissions to the installation path $install_path"
+      echo "If you have administrative privileges, enter your password to install $package_to_build."
+    fi &&
+    echo "Installing with the command '$SUDO make install'" &&
+    $SUDO make install
   else
     $download_path/$package_source_directory/configure --prefix=$install_path &&
+    echo "Building with the following command:" &&
+    echo "CC=$CC CXX=$CXX make -j $num_threads" &&
     CC=$CC CXX=$CXX make -j $num_threads &&
     printf "Installing $package_to_build in $install_path.\n" &&
-    make install
+    if [[ ! -z $SUDO ]]; then
+      echo "You do not have write permissions to the installation path $install_path"
+      echo "If you have administrative privileges, enter your password to install $package_to_build."
+    fi &&
+    echo "Installing with the command '$SUDO make install'" &&
+    $SUDO make install
   fi &&
   popd
 }

--- a/install_prerequisites/set_SUDO.sh
+++ b/install_prerequisites/set_SUDO.sh
@@ -21,6 +21,6 @@ set_SUDO_if_necessary()
     else
       printf "no.\n"
       SUDO=$SUDO_COMMAND
-    fi  
-  fi  
+    fi
+  fi
 }

--- a/install_prerequisites/set_SUDO.sh
+++ b/install_prerequisites/set_SUDO.sh
@@ -12,7 +12,7 @@ set_SUDO_if_necessary()
     else
       printf "no\n"
       SUDO=$SUDO_COMMAND
-    fi  
+    fi
   else
     printf "no\n"
     printf "Checking whether I can create the installation path... "

--- a/install_prerequisites/set_SUDO.sh
+++ b/install_prerequisites/set_SUDO.sh
@@ -1,0 +1,26 @@
+# Define the sudo command to be used if the installation path requires administrative permissions
+set_SUDO_if_necessary()
+{
+  SUDO_COMMAND="sudo env LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+  printf "$this_script: $package_to_build installation path is $install_path"
+  printf "Checking whether the $package_to_build installation path exists... "
+  if [[ -d "$install_path" ]]; then
+    printf "yes\n"
+    printf "Checking whether I have write permissions to the installation path... "
+    if [[ -w "$install_path" ]]; then
+      printf "yes\n"
+    else
+      printf "no\n"
+      SUDO=$SUDO_COMMAND
+    fi  
+  else
+    printf "no\n"
+    printf "Checking whether I can create the installation path... "
+    if mkdir -p $install_path >& /dev/null; then
+      printf "yes.\n"
+    else
+      printf "no.\n"
+      SUDO=$SUDO_COMMAND
+    fi  
+  fi  
+}


### PR DESCRIPTION
This commit eliminates the need for global "sudo ./install.sh" or "sudo ./build" when installing to a path that requires sudo privileges.  Now the need for sudo is detected during the execution of "install.sh" or "build" and the subsequent use of sudo is localized to the places where it is needed (e.g., "sudo make install" or "sudo mv setup.sh $install_path".  