### PR TITLE
Add script to change git settings and use hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,10 @@
 *.F90 text
 *.md text
 *.txt text
+*.sh text
+install_prerequisites/build text
+*.cu text
+*.x64 text
 
 # Denote all files that are truly binary and should not be modified.
 *.mod binary
@@ -22,3 +26,4 @@
 .travis.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+developer-scripts export-ignore

--- a/developer-scripts/git-hooks/applypatch-msg.sample
+++ b/developer-scripts/git-hooks/applypatch-msg.sample
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# An example hook script to check the commit log message taken by
+# applypatch from an e-mail message.
+#
+# The hook should exit with non-zero status after issuing an
+# appropriate message if it wants to stop the commit.  The hook is
+# allowed to edit the commit message file.
+#
+# To enable this hook, rename this file to "applypatch-msg".
+
+. git-sh-setup
+test -x "$GIT_DIR/hooks/commit-msg" &&
+	exec "$GIT_DIR/hooks/commit-msg" ${1+"$@"}
+:

--- a/developer-scripts/git-hooks/commit-msg
+++ b/developer-scripts/git-hooks/commit-msg
@@ -1,0 +1,111 @@
+#!/bin/sh
+#
+# An example hook script to check the commit log message.
+# Called by "git commit" with one argument, the name of the file
+# that has the commit message.  The hook should exit with non-zero
+# status after issuing an appropriate message if it wants to stop the
+# commit.  The hook is allowed to edit the commit message file.
+#
+# To enable this hook, rename this file to "commit-msg".
+
+# Uncomment the below to add a Signed-off-by line to the message.
+# Doing this in a hook is a bad idea in general, but the prepare-commit-msg
+# hook is more suited to it.
+#
+# SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+# grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"
+
+# error message function for writing good commit messages
+error_message () {
+    cat <<\EOF >&2
+Error: bad commit message format. A copy of your commit message is in:
+`.git/COMMIT_EDITMSG`. Please fix it or write a new one according to the
+guidlines below.
+
+The first line of a commit message should start with a capitalized imperative
+verb used in a phrase to summarize the change. This first line must be less
+than 50 characters, followed by an additional blank line. Further detials are
+added after these first two lines, and may be up to 72 characters in length.
+
+This is so that `--oneline` formatted `git log`s will contain human readable,
+meaningful information, and the summaries on Github.com will also contain
+this concise summary. The 72 line limit is to ensure propper formatting on
+all terminals.
+
+Here is an example of a good commit message:
+
+```
+Redirect user to the requested page after login
+
+https://github.com/sourceryinstitute/opencoarrays/Issues/29
+
+Users were being redirected to the home page after login, which is less
+useful than redirecting to the page they had originally requested before
+being redirected to the login form.
+
+* Store requested path in a session variable
+* Redirect to the stored location after successfully logging in the user
+* Fixes #1
+```
+
+As opposed to doing something bad like this:
+
+`git commit -m "Fix login bug"`
+
+For more information on writting good commit messages,
+and keeping a clean history, please see:
+
+ 1. https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
+ 2. http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+ 3. https://www.reviewboard.org/docs/codebase/dev/git/clean-commits/
+
+And for funny examples of what not to do, see: http://whatthecommit.com
+EOF
+
+}
+
+let status=0
+
+# This example catches duplicate Signed-off-by lines.
+
+test "" = "$(grep '^Signed-off-by: ' "$1" |
+	 sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d')" || {
+	echo >&2 "Duplicate Signed-off-by lines."
+	let status=1
+}
+
+# Check that the first line of the commit starts with a
+# capitalized letter.
+if ! (head -n 1 $1 | grep '^[A-Z]' &>/dev/null ); then
+    echo >&2 "First word of commit message must be a capitalized imperative verb.\n"
+    let status=1
+fi
+
+# Check each line for propper length
+ln=0
+cat $1 | \
+    while read line; do
+	let ln+=1
+	nchars=$(wc -c <<<$line)
+	if [[ "$ln" -eq "1" ]]; then
+	    if [[ "$nchars" -gt "51" ]]; then
+		echo >&2 "First line of commit message too long ($nchars > 50 chars)\n"
+		let status=1
+	    fi
+	elif [[ "$ln" -eq "2" ]]; then
+	    if [[ "$nchars" -gt "1" ]] && ! grep '^#' <<<"$line" >/dev/null; then
+		echo >&2 "Second line of commit message not blank\n"
+		let status=1
+	    fi
+	else
+	    if [[ "$nchars" -gt "72" ]]; then
+		echo >&2 "Line $ln of commit message too long ($nchars > 72 chars)\n"
+		let status=1
+	    fi
+	fi
+    done
+
+if [[ $status != 0 ]]; then
+    error_message
+    exit 1
+fi

--- a/developer-scripts/git-hooks/post-update.sample
+++ b/developer-scripts/git-hooks/post-update.sample
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# An example hook script to prepare a packed repository for use over
+# dumb transports.
+#
+# To enable this hook, rename this file to "post-update".
+
+exec git update-server-info

--- a/developer-scripts/git-hooks/pre-applypatch.sample
+++ b/developer-scripts/git-hooks/pre-applypatch.sample
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed
+# by applypatch from an e-mail message.
+#
+# The hook should exit with non-zero status after issuing an
+# appropriate message if it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-applypatch".
+
+. git-sh-setup
+test -x "$GIT_DIR/hooks/pre-commit" &&
+	exec "$GIT_DIR/hooks/pre-commit" ${1+"$@"}
+:

--- a/developer-scripts/git-hooks/pre-commit
+++ b/developer-scripts/git-hooks/pre-commit
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+function ends_with_newline() {
+    test ! -s "$1" || test $(tail -r -c1 "$1" | xxd -ps) = "0a"
+}
+
+function ends_with_single_new_line () {
+    tail -2 "$1" | ( read x && read y && ! grep '^[[:blank:]]\+$' <<<$x >/dev/null)
+}
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# if we are in the middle of merging skip hooks
+MERGING=$(git rev-parse MERGE_HEAD 2>&1)
+if [[ $? == 0 ]]; then
+  exit 0
+fi
+
+# if we are in the middle of merging skip hooks
+PICKING=$(git rev-parse CHERRY_PICK_HEAD 2>&1)
+if [[ $? == 0 ]]; then
+  exit 0
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+let status=0
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat &>2 <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	let status=1
+fi
+
+# If there is a file that does not end with a newline, print its name and fail.
+for f in $(git diff-index --name-status --cached $against | grep -v ^D | cut -c3-); do
+    if [[ "$f" =~ ([.](h|m|c|rb|sh|py|txt|md|f90|F90|cmake|x64|csh)|makefile|Makefile)$ ]] ||
+       head -n 1 | grep '^#!/'; then
+	if ! ends_with_newline "$f"; then
+	    echo &>2 "No newline at end of file: $f\n"
+	    let status=1
+	fi
+    fi
+done
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against -- || let status=1
+
+if [[ $status != 0 ]]; then
+    exit 1
+fi

--- a/developer-scripts/git-hooks/pre-push
+++ b/developer-scripts/git-hooks/pre-push
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	if [ "$local_sha" = $z40 ]
+	then
+		# Handle delete
+		:
+	else
+		if [ "$remote_sha" = $z40 ]
+		then
+			# New branch, examine all commits
+			range="$local_sha"
+		else
+			# Update to existing branch, examine new commits
+			range="$remote_sha..$local_sha"
+		fi
+
+		# Check for WIP commit
+		commit=`git rev-list -n 1 --grep '^WIP' "$range"`
+		if [ -n "$commit" ]
+		then
+			echo >&2 "Found WIP commit in $local_ref, not pushing"
+			exit 1
+		fi
+	fi
+done
+exit 0

--- a/developer-scripts/git-hooks/pre-rebase.sample
+++ b/developer-scripts/git-hooks/pre-rebase.sample
@@ -1,0 +1,169 @@
+#!/bin/sh
+#
+# Copyright (c) 2006, 2008 Junio C Hamano
+#
+# The "pre-rebase" hook is run just before "git rebase" starts doing
+# its job, and can prevent the command from running by exiting with
+# non-zero status.
+#
+# The hook is called with the following parameters:
+#
+# $1 -- the upstream the series was forked from.
+# $2 -- the branch being rebased (or empty when rebasing the current branch).
+#
+# This sample shows how to prevent topic branches that are already
+# merged to 'next' branch from getting rebased, because allowing it
+# would result in rebasing already published history.
+
+publish=next
+basebranch="$1"
+if test "$#" = 2
+then
+	topic="refs/heads/$2"
+else
+	topic=`git symbolic-ref HEAD` ||
+	exit 0 ;# we do not interrupt rebasing detached HEAD
+fi
+
+case "$topic" in
+refs/heads/??/*)
+	;;
+*)
+	exit 0 ;# we do not interrupt others.
+	;;
+esac
+
+# Now we are dealing with a topic branch being rebased
+# on top of master.  Is it OK to rebase it?
+
+# Does the topic really exist?
+git show-ref -q "$topic" || {
+	echo >&2 "No such branch $topic"
+	exit 1
+}
+
+# Is topic fully merged to master?
+not_in_master=`git rev-list --pretty=oneline ^master "$topic"`
+if test -z "$not_in_master"
+then
+	echo >&2 "$topic is fully merged to master; better remove it."
+	exit 1 ;# we could allow it, but there is no point.
+fi
+
+# Is topic ever merged to next?  If so you should not be rebasing it.
+only_next_1=`git rev-list ^master "^$topic" ${publish} | sort`
+only_next_2=`git rev-list ^master           ${publish} | sort`
+if test "$only_next_1" = "$only_next_2"
+then
+	not_in_topic=`git rev-list "^$topic" master`
+	if test -z "$not_in_topic"
+	then
+		echo >&2 "$topic is already up-to-date with master"
+		exit 1 ;# we could allow it, but there is no point.
+	else
+		exit 0
+	fi
+else
+	not_in_next=`git rev-list --pretty=oneline ^${publish} "$topic"`
+	/usr/bin/perl -e '
+		my $topic = $ARGV[0];
+		my $msg = "* $topic has commits already merged to public branch:\n";
+		my (%not_in_next) = map {
+			/^([0-9a-f]+) /;
+			($1 => 1);
+		} split(/\n/, $ARGV[1]);
+		for my $elem (map {
+				/^([0-9a-f]+) (.*)$/;
+				[$1 => $2];
+			} split(/\n/, $ARGV[2])) {
+			if (!exists $not_in_next{$elem->[0]}) {
+				if ($msg) {
+					print STDERR $msg;
+					undef $msg;
+				}
+				print STDERR " $elem->[1]\n";
+			}
+		}
+	' "$topic" "$not_in_next" "$not_in_master"
+	exit 1
+fi
+
+exit 0
+
+################################################################
+
+This sample hook safeguards topic branches that have been
+published from being rewound.
+
+The workflow assumed here is:
+
+ * Once a topic branch forks from "master", "master" is never
+   merged into it again (either directly or indirectly).
+
+ * Once a topic branch is fully cooked and merged into "master",
+   it is deleted.  If you need to build on top of it to correct
+   earlier mistakes, a new topic branch is created by forking at
+   the tip of the "master".  This is not strictly necessary, but
+   it makes it easier to keep your history simple.
+
+ * Whenever you need to test or publish your changes to topic
+   branches, merge them into "next" branch.
+
+The script, being an example, hardcodes the publish branch name
+to be "next", but it is trivial to make it configurable via
+$GIT_DIR/config mechanism.
+
+With this workflow, you would want to know:
+
+(1) ... if a topic branch has ever been merged to "next".  Young
+    topic branches can have stupid mistakes you would rather
+    clean up before publishing, and things that have not been
+    merged into other branches can be easily rebased without
+    affecting other people.  But once it is published, you would
+    not want to rewind it.
+
+(2) ... if a topic branch has been fully merged to "master".
+    Then you can delete it.  More importantly, you should not
+    build on top of it -- other people may already want to
+    change things related to the topic as patches against your
+    "master", so if you need further changes, it is better to
+    fork the topic (perhaps with the same name) afresh from the
+    tip of "master".
+
+Let's look at this example:
+
+		   o---o---o---o---o---o---o---o---o---o "next"
+		  /       /           /           /
+		 /   a---a---b A     /           /
+		/   /               /           /
+	       /   /   c---c---c---c B         /
+	      /   /   /             \         /
+	     /   /   /   b---b C     \       /
+	    /   /   /   /             \     /
+    ---o---o---o---o---o---o---o---o---o---o---o "master"
+
+
+A, B and C are topic branches.
+
+ * A has one fix since it was merged up to "next".
+
+ * B has finished.  It has been fully merged up to "master" and "next",
+   and is ready to be deleted.
+
+ * C has not merged to "next" at all.
+
+We would want to allow C to be rebased, refuse A, and encourage
+B to be deleted.
+
+To compute (1):
+
+	git rev-list ^master ^topic next
+	git rev-list ^master        next
+
+	if these match, topic has not merged in next at all.
+
+To compute (2):
+
+	git rev-list master..topic
+
+	if this is empty, it is fully merged to "master".

--- a/developer-scripts/git-hooks/prepare-commit-msg.sample
+++ b/developer-scripts/git-hooks/prepare-commit-msg.sample
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# An example hook script to prepare the commit log message.
+# Called by "git commit" with the name of the file that has the
+# commit message, followed by the description of the commit
+# message's source.  The hook's purpose is to edit the commit
+# message file.  If the hook fails with a non-zero status,
+# the commit is aborted.
+#
+# To enable this hook, rename this file to "prepare-commit-msg".
+
+# This hook includes three examples.  The first comments out the
+# "Conflicts:" part of a merge commit.
+#
+# The second includes the output of "git diff --name-status -r"
+# into the message, just before the "git status" output.  It is
+# commented because it doesn't cope with --amend or with squashed
+# commits.
+#
+# The third example adds a Signed-off-by line to the message, that can
+# still be edited.  This is rarely a good idea.
+
+case "$2,$3" in
+  merge,)
+    /usr/bin/perl -i.bak -ne 's/^/# /, s/^# #/#/ if /^Conflicts/ .. /#/; print' "$1" ;;
+
+# ,|template,)
+#   /usr/bin/perl -i.bak -pe '
+#      print "\n" . `git diff --cached --name-status -r`
+#	 if /^#/ && $first++ == 0' "$1" ;;
+
+  *) ;;
+esac
+
+# SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+# grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"

--- a/developer-scripts/git-hooks/update.sample
+++ b/developer-scripts/git-hooks/update.sample
@@ -1,0 +1,128 @@
+#!/bin/sh
+#
+# An example hook script to blocks unannotated tags from entering.
+# Called by "git receive-pack" with arguments: refname sha1-old sha1-new
+#
+# To enable this hook, rename this file to "update".
+#
+# Config
+# ------
+# hooks.allowunannotated
+#   This boolean sets whether unannotated tags will be allowed into the
+#   repository.  By default they won't be.
+# hooks.allowdeletetag
+#   This boolean sets whether deleting tags will be allowed in the
+#   repository.  By default they won't be.
+# hooks.allowmodifytag
+#   This boolean sets whether a tag may be modified after creation. By default
+#   it won't be.
+# hooks.allowdeletebranch
+#   This boolean sets whether deleting branches will be allowed in the
+#   repository.  By default they won't be.
+# hooks.denycreatebranch
+#   This boolean sets whether remotely creating branches will be denied
+#   in the repository.  By default this is allowed.
+#
+
+# --- Command line
+refname="$1"
+oldrev="$2"
+newrev="$3"
+
+# --- Safety check
+if [ -z "$GIT_DIR" ]; then
+	echo "Don't run this script from the command line." >&2
+	echo " (if you want, you could supply GIT_DIR then run" >&2
+	echo "  $0 <ref> <oldrev> <newrev>)" >&2
+	exit 1
+fi
+
+if [ -z "$refname" -o -z "$oldrev" -o -z "$newrev" ]; then
+	echo "usage: $0 <ref> <oldrev> <newrev>" >&2
+	exit 1
+fi
+
+# --- Config
+allowunannotated=$(git config --bool hooks.allowunannotated)
+allowdeletebranch=$(git config --bool hooks.allowdeletebranch)
+denycreatebranch=$(git config --bool hooks.denycreatebranch)
+allowdeletetag=$(git config --bool hooks.allowdeletetag)
+allowmodifytag=$(git config --bool hooks.allowmodifytag)
+
+# check for no description
+projectdesc=$(sed -e '1q' "$GIT_DIR/description")
+case "$projectdesc" in
+"Unnamed repository"* | "")
+	echo "*** Project description file hasn't been set" >&2
+	exit 1
+	;;
+esac
+
+# --- Check types
+# if $newrev is 0000...0000, it's a commit to delete a ref.
+zero="0000000000000000000000000000000000000000"
+if [ "$newrev" = "$zero" ]; then
+	newrev_type=delete
+else
+	newrev_type=$(git cat-file -t $newrev)
+fi
+
+case "$refname","$newrev_type" in
+	refs/tags/*,commit)
+		# un-annotated tag
+		short_refname=${refname##refs/tags/}
+		if [ "$allowunannotated" != "true" ]; then
+			echo "*** The un-annotated tag, $short_refname, is not allowed in this repository" >&2
+			echo "*** Use 'git tag [ -a | -s ]' for tags you want to propagate." >&2
+			exit 1
+		fi
+		;;
+	refs/tags/*,delete)
+		# delete tag
+		if [ "$allowdeletetag" != "true" ]; then
+			echo "*** Deleting a tag is not allowed in this repository" >&2
+			exit 1
+		fi
+		;;
+	refs/tags/*,tag)
+		# annotated tag
+		if [ "$allowmodifytag" != "true" ] && git rev-parse $refname > /dev/null 2>&1
+		then
+			echo "*** Tag '$refname' already exists." >&2
+			echo "*** Modifying a tag is not allowed in this repository." >&2
+			exit 1
+		fi
+		;;
+	refs/heads/*,commit)
+		# branch
+		if [ "$oldrev" = "$zero" -a "$denycreatebranch" = "true" ]; then
+			echo "*** Creating a branch is not allowed in this repository" >&2
+			exit 1
+		fi
+		;;
+	refs/heads/*,delete)
+		# delete branch
+		if [ "$allowdeletebranch" != "true" ]; then
+			echo "*** Deleting a branch is not allowed in this repository" >&2
+			exit 1
+		fi
+		;;
+	refs/remotes/*,commit)
+		# tracking branch
+		;;
+	refs/remotes/*,delete)
+		# delete tracking branch
+		if [ "$allowdeletebranch" != "true" ]; then
+			echo "*** Deleting a tracking branch is not allowed in this repository" >&2
+			exit 1
+		fi
+		;;
+	*)
+		# Anything else (is there anything else?)
+		echo "*** Update hook: unknown type of update to ref $refname of type $newrev_type" >&2
+		exit 1
+		;;
+esac
+
+# --- Finished
+exit 0

--- a/developer-scripts/setup-git.sh
+++ b/developer-scripts/setup-git.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Script to congigure OpenCoarrays contributor's git environment
+# and add local git-hooks scripts to ensure properly
+let global=0
+if [[ "$1" ]]; then
+    if [[ "$1" == "--global" ]]; then
+	let global=1
+	echo "WARNING: Settings will be applied globally. This may over-write some of your global git settings."
+	read -p "Press Ctrl-C to abort, and try again without \`--global\` or press any key to contibue" foo
+    else
+	echo -e "Usage: $0 [--global] [--help]\n"
+	echo "This script is to configure your git environment"
+	echo "For contributing to OpenCoarrays. The \`--help\`"
+	echo "flag will print this message. The \`--global\`"
+	echo "flag will install the settings and hooks globally"
+	echo "for the current git user and their future projects"
+	exit 0
+    fi
+fi
+
+if [[ $global -eq 1 ]]; then
+    flags=--global
+fi
+
+system=$(uname)
+
+if [[ "X$system" == "XDarwin" || "X$system" == "XLinux" ]]; then
+    git config $flags core.autocrlf input
+else # assume windows
+    git fonfig $flags core.autocrlf true
+fi
+
+git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,blank-at-eof
+
+git config $flags apply.whitespace fix
+
+git config $flags color.diff.whitespace red reverse
+
+gitroot="$(git rev-parse --show-toplevel)"
+echo "WARNING: About to install and overwrite project level githooks in $gitroot/.git/hooks"
+read -p "Press Ctrl-C to abort or any key to continue" foo
+for f in "$gitroot/developer-scripts/git-hooks/"*; do
+    echo "Copying $f"
+    cp "$f" "$gitroot/.git/hooks/"
+done
+
+if [[ $global -eq 1 ]]; then
+    if [ -e "$HOME/.git_template" ]; then
+	echo "Aborting global git hooks installation since user appears to already have a $HOME/.git_template directory"
+	exit 1
+    fi
+    mkdir -p "$HOME/.git_template/hooks/"
+    for f in "$gitroot/developer-scripts/git-hooks/"*; do
+	echo "Copying $f"
+	cp "$f" "$HOME/.git_template/hooks/"
+    done
+    git config --global init.templatedir "$HOME/.git_template"
+fi


### PR DESCRIPTION
 - pre-commit hook to check for white-space errors
 - commit-msg hook to ensure commit messages are properly formatted
   - Commit messages should start with a capitalized imperative verb "do, fix, enable" and a brief summary, less than 50 characters long of what the commit is about
   - If multiple lines, the second line should be left blank.
   - subsequent lines should not be more than 72 characters long
 - setup line endings and white space

For more info on writing good commit messages please see:
 1. https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
 2. http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 3. https://www.reviewboard.org/docs/codebase/dev/git/clean-commits/

The 50 character limit may seem arbitrary, but it is important for how Github.com shows commit messages, and for how `git log --oneline` and similar display the message contents.

Once @rouson and @afanfa have had a chance to look this over and voice any concerns or make requests for changes, I will merge that. After that, you can configure your repository (or the repository AND global git settings) by running:

`developer-scripts/setup-git.sh`

or 

`developer-scripts/setup-git.sh --global`

to get all the settings properly configured.