### PR TITLE
replay changes to silence inconsequential errors from bad PR #92

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set ( CMAKE_BUILD_TYPE "Release"
 set_property ( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES} )
 
 #Name project and specify source languages
-project(opencoarrays VERSION 1.2.2 LANGUAGES C Fortran)
+project(opencoarrays VERSION 1.2.3 LANGUAGES C Fortran)
 
 #Print an error message on an attempt to build inside the source directory tree:
 if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
PR #92 accidentally merged `devel` into the working branch before merging back into master. This PR was reverted via PR #95 and the intended changes are now being replayed on top of master, without the unintended merge of `devel` into `master`.