### PR TITLE
Eliminate inconsequation install error messages.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -691,9 +691,6 @@ print_header()
   fi
 }
 
-. install_prerequisites/set_SUDO.sh
-set_SUDO_if_necessary 
-
 build_opencoarrays()
 {
   print_header
@@ -843,6 +840,8 @@ else # Find or install prerequisites and install OpenCoarrays
 
   cd install_prerequisites &&
   installation_record=install-opencoarrays.log &&
+  . set_SUDO.sh &&
+  set_SUDO_if_necessary  &&
   CMAKE=$CMAKE build_opencoarrays 2>&1 | tee ../$installation_record
   report_results 2>&1 | tee -a ../$installation_record
 

--- a/install_prerequisites/stack.sh
+++ b/install_prerequisites/stack.sh
@@ -47,8 +47,8 @@ function stack_new
         return 1
     fi
 
-    eval "declare -ag _stack_$1"
-    eval "declare -ig _stack_$1_i"
+    eval "declare -ag _stack_$1" >& /dev/null
+    eval "declare -ig _stack_$1_i" >& /dev/null
     eval "let _stack_$1_i=0"
     return 0
 }


### PR DESCRIPTION
The stack_new function invoked by install.sh outputs inconsequential
errors on OS X because of the lack of support for the -g flag in bash
"eval".  This commit pipes that output to /dev/null.

(cherry picked from commit 5491f66ea81e2ca24d42abd78f65d4e4e92b7eed)

I thought I had already fixed things, but apparently merge commits are more complicated than I fully understand. This *should* bring `master` back to where we want it. I'm poking around a little bit more to see if that is indeed the case.