### PR TITLE
Add m4 to dependency tree

### DIFF
--- a/doc/dependency_tree/opencoarrays-tree.txt
+++ b/doc/dependency_tree/opencoarrays-tree.txt
@@ -4,8 +4,9 @@ opencoarrays
     └── gcc-5.1.0
         ├── flex-2.6.0
         │   └── bison-3.0.4
+        │       └── m4-1.4.17
         ├── gmp
         ├── mpc
         └── mpfr
 
-8 directories, 0 files
+9 directories, 0 files

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@
 # -- This script installs OpenCoarrays and its prerequisites.
 #
 # OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
-# Copyright (c) 2015, Sourcery, Inc.
-# Copyright (c) 2015, Sourcery Institute
+# Copyright (c) 2015-2016, Sourcery, Inc.
+# Copyright (c) 2015-2016, Sourcery Institute
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -207,7 +207,7 @@ find_or_install()
     elif [[ "$package_in_path" == "true" ]]; then
       printf "$this_script: Checking whether $package in PATH is version < $minimum_version... "
 
-      if [[ "$package_version_in_path" < "$executable version $minimum_version" ]]; then
+      if ! ./check_version.sh $package `./build $package --default --query-version`; then
         printf "yes.\n"
         # Here we place $package on the dependency stack to trigger the build of the above file:
         stack_push dependency_pkg $package "none"
@@ -400,7 +400,7 @@ find_or_install()
     elif [[ "$package_in_path" == "true" ]]; then
 
       printf "$this_script: Checking whether $package in PATH is version < $minimum_version... "
-      if [[ "$package_version_in_path" < "$executable $minimum_version" ]]; then
+      if ! ./check_version.sh $package `./build $package --default --query-version`; then
         printf "yes\n"
 
         export FLEX="$package_install_path/bin/$executable"
@@ -460,7 +460,7 @@ find_or_install()
 
     elif [[ "$package_in_path" == "true" ]]; then
       printf "$this_script: Checking whether $package executable $executable in PATH is version < $minimum_version... "
-      if [[ "$package_version_in_path" < "$package (GNU Bison) $minimum_version" ]]; then
+      if ! ./check_version.sh $package `./build $package --default --query-version`; then
         printf "yes.\n"
         export YACC="$package_install_path/bin/$executable"
         # Trigger 'find_or_install m4' and subsequent build of $package
@@ -519,7 +519,7 @@ find_or_install()
 
     elif [[ "$package_in_path" == "true" ]]; then
       printf "$this_script: Checking whether $package executable $executable in PATH is version < $minimum_version... "
-      if [[ "$package_version_in_path" < "$package (GNU Bison) $minimum_version" ]]; then
+      if ! ./check_version.sh $package `./build $package --default --query-version`; then
         printf "yes.\n"
         export M4="$package_install_path/bin/m4"
         # Halt the recursion and signal that there are no prerequisites to build
@@ -905,8 +905,8 @@ elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
   echo "opencoarrays $opencoarrays_version"
   echo ""
   echo "OpenCoarrays installer"
-  echo "Copyright (C) 2015 Sourcery, Inc."
-  echo "Copyright (C) 2015 Sourcery Institute"
+  echo "Copyright (C) 2015-2016 Sourcery, Inc."
+  echo "Copyright (C) 2015-2016 Sourcery Institute"
   echo ""
   echo "OpenCoarrays comes with NO WARRANTY, to the extent permitted by law."
   echo "You may redistribute copies of $this_script under the terms of the"

--- a/install.sh
+++ b/install.sh
@@ -408,14 +408,20 @@ find_or_install()
         stack_push dependency_pkg "bison"
         stack_push dependency_exe "yacc"
         stack_push dependency_path `./build bison --default --query-path`
-
       else
         printf "no.\n"
         printf "$this_script: Using the $executable found in the PATH.\n"
         export FLEX=$executable
         stack_push acceptable_in_path $package $executable
-        # Halt the recursion by removing flex from the dependency stack and indicating
-        # that none of the prerequisites required to build flex are needed.
+        # Remove $package from the dependency stack
+        stack_pop dependency_pkg package_done
+        stack_pop dependency_exe executable_done
+        stack_pop dependency_path package_done_path
+        # Put $package onto the script_installed log
+        stack_push script_installed package_done
+        stack_push script_installed executable_done
+        stack_push script_installed package_done_path
+        # Halt the recursion and signal that none of $package's prerequisites need to be built
         stack_push dependency_pkg "none"
         stack_push dependency_exe "none"
         stack_push dependency_path "none"

--- a/install.sh
+++ b/install.sh
@@ -265,7 +265,7 @@ find_or_install()
         stack_push dependency_path "none" `./build $package --default --query-path` `./build gcc --default --query-path`
       else
         printf "yes.\n"
-        printf "$this_script: Checking whether $executable in PATH wraps gfortran version 5.1.0 or later... "
+        printf "$this_script: Checking whether $executable in PATH wraps gfortran version 5.3.0 or later... "
         $executable acceptable_compiler.f90 -o acceptable_compiler
         $executable print_true.f90 -o print_true
         acceptable=`./acceptable_compiler`
@@ -332,7 +332,7 @@ find_or_install()
       stack_push dependency_path "none"
 
     elif [[ "$package_in_path" == "true" ]]; then
-      printf "$this_script: Checking whether $executable in PATH is version 5.1.0 or later..."
+      printf "$this_script: Checking whether $executable in PATH is version 5.3.0 or later..."
       $executable -o acceptable_compiler acceptable_compiler.f90
       $executable -o print_true print_true.f90
       is_true=`./print_true`
@@ -712,7 +712,7 @@ print_header()
   clear
   echo ""
   echo "*** A default build of OpenCoarrays requires CMake 3.4.0 or later     ***"
-  echo "*** and MPICH 3.1.4 wrapping GCC Fortran (gfortran) 5.1.0 or later.   ***"
+  echo "*** and MPICH 3.1.4 wrapping GCC Fortran (gfortran) 5.3.0 or later.   ***"
   echo "*** Additionally, CMake, MPICH, and GCC have their own prerequisites. ***"
   echo "*** This script will check for most known requirements in your PATH   ***"
   echo "*** environment variable and in the default installation directory    ***"

--- a/install_prerequisites/acceptable_compiler.f90
+++ b/install_prerequisites/acceptable_compiler.f90
@@ -35,5 +35,5 @@
 program main
   use iso_fortran_env, only : compiler_version
   implicit none
-  print *,compiler_version() >= "GCC version 5.1.0 "
+  print *,compiler_version() >= "GCC version 5.3.0 "
 end program

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -5,8 +5,8 @@
 # -- This script downloads and installs the OpenCoarrays prerequisites
 #
 # OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
-# Copyright (c) 2015, Sourcery, Inc.
-# Copyright (c) 2015, Sourcery Institute
+# Copyright (c) 2015-2016, Sourcery, Inc.
+# Copyright (c) 2015-2016, Sourcery Institute
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -57,22 +57,52 @@ usage()
     echo ""
     echo "[exit 10]"
     exit 10
+ 
+# Private usage information
+#
+# The following arguments are intentionally not documented in the above public usage information because
+# they are intended for use by ../install.sh only rather than for use interactively at the command line:
+#    Argument $2  Argument $3      Description 
+#    --default                     install the default version for the corresponding package
+#    --default    --query-path     return the default installation location for the package
+#    --default    --query-version  return the default version for the package
+#    --default    --query-url      return the default download location for the package
+#
+#   Example: ./build gcc --default --query-path
+#
+#  With the exception of gcc, all uses of "--default" refer to the package version that would be downloaded
+#  if no version is specified, e.g., "./build mpich". By contrast, "./build gcc" downloads the latest 
+#  pre-release, development branch (the "trunk"), whereas "./build gcc --default" downloads a released 
+#  version of gcc.
+#
+# The following argument works only with gcc and is mutually exclusive with the above private arguments 
+# (it could be extended to work with any svn download):
+#    Argument $2  Description 
+#    --avail      list the development branches available for checkout
+#    -a           same as --avail
+#
+#   Example: ./build gcc --avail
 }
 
 # If the package name is recognized, then set the default version.
 # Otherwise, list the allowable package names and default versions and then exit.
 set_default_version()
 {
+  version_requested=$2
   if [[ $package_to_build == "--list" || $package_to_build == "-l" ]]; then
        printf "\n"
        printf "The '$this_script' script can build the following packages:\n"
+  elif [[ $package_to_build == "gcc" && $version_requested == "--default" ]]; then
+    gcc_version="5.3.0"
+  else
+    gcc_version="trunk"
   fi
   # This is a bash 3 hack standing in for a bash 4 hash (bash 3 is the lowest common
   # denominator because, for licensing reasons, OS X only has bash 3 by default.)
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_version=(
     "cmake:3.4.0"
-    "gcc:gcc-5-branch"
+    "gcc:$gcc_version"
     "mpich:3.1.4"
     "wget:1.16.3"
     "flex:2.6.0"
@@ -100,7 +130,7 @@ set_default_version()
      elif [[ $package_to_build == "$KEY" ]]; then
        # We recognize the package name so we set the default version:
        verbosity=$1
-       if [[ $verbosity != "quietly" ]]; then
+       if [[ $2 != "--default" ]]; then
          printf "Using default version $VALUE\n"
        fi
        default_version=$VALUE
@@ -116,11 +146,16 @@ set_default_version()
 
 check_prerequisites()
 {
+  if [[ $package_to_build == "gcc" && $version_requested == "--default" ]]; then
+    gcc_fetch="ftp"
+  else
+    gcc_fetch="svn"
+  fi
   # This is a bash 3 hack standing in for a bash 4 hash (bash 3 is the lowest common
   # denominator because, for licensing reasons, OS X only has bash 3 by default.)
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_download_mechanism=(
-    "gcc:svn"
+    "gcc:$gcc_fetch"
     "wget:ftp"
     "cmake:wget"
     "mpich:wget"
@@ -166,9 +201,13 @@ set_url()
 {
   if [[ $package_to_build == 'cmake' ]]; then
     major_minor="${version_to_build%.*}"
+  elif [[ "$package_to_build" == "gcc" && "$version_to_build" == "$default_version" ]]; then
+    gcc_url_head="http://ftpmirror.gnu.org/gcc/gcc-5.3.0/"
+  else
+    gcc_url_head="svn://gcc.gnu.org/svn/gcc/"
   fi
   package_url_head=(
-    "gcc;svn://gcc.gnu.org/svn/gcc/"
+    "gcc;$gcc_url_head"
     "wget;ftp.gnu.org:/gnu/wget/"
     "m4;ftp.gnu.org:/gnu/m4/"
     "pkg-config;http://pkgconfig.freedesktop.org/releases/"
@@ -202,7 +241,7 @@ set_url()
     elif [[ $version_to_build == '--avail' || $version_to_build == '-a' ]]; then
       gcc_tail='branches'
     else
-      gcc_tail=/branches/$version_to_build
+      gcc_tail="gcc-$version_to_build.tar.bz2"
     fi
   fi
   package_url_tail=(
@@ -299,6 +338,7 @@ download_if_necessary()
     printf "Downloading $package_to_build $version_to_build to the following location:\n"
     printf "$download_path/$package_source_directory \n"
     printf "Download command: $fetch $args $url\n"
+    printf "Depending on the file size and network bandwidth, this could take several minutes or longer."
     $fetch $args $url
     if [[ $version_to_build == '--avail' || $version_to_build == '-a' ]]; then
       # In this case, args="ls" and the list of available versions has been printed so we can move on.
@@ -390,11 +430,8 @@ package_to_build=$1
 
 # Interpret the second command-line argument, if present, as the package version.
 # Otherwise, set the default package version.
-if [[ -z $2 ]]; then
-  set_default_version
-  version_to_build=$default_version
-elif [[ $2 == "--default" ]]; then
-  set_default_version "quietly"
+if [[ -z $2 || $2 == "--default"  ]]; then
+  set_default_version $*
   version_to_build=$default_version
 else
   version_to_build=$2
@@ -446,7 +483,7 @@ elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
 else
   # Download, unpack, and build CMake
   download_path=${PWD}
-  check_prerequisites &&
+  check_prerequisites $* &&
   download_if_necessary &&
   unpack_if_necessary &&
   CC=$CC CXX=$CXX build_and_install $package_to_build $version_to_build $install_path $num_threads $download_path \

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -72,7 +72,7 @@ set_default_version()
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_version=(
     "cmake:3.4.0"
-    "gcc:trunk"
+    "gcc:gcc-5-branch"
     "mpich:3.1.4"
     "wget:1.16.3"
     "flex:2.6.0"
@@ -304,12 +304,17 @@ download_if_necessary()
       # In this case, args="ls" and the list of available versions has been printed so we can move on.
       exit 1
     fi
-    if [ -f $download_path/$url_tail ] || [ -d $download_path/$url_tail ]; then
-      echo "Download succeeded. $url_tail is in the following location:"
-      echo "$download_path"
+    if [[ "$fetch" == "svn" ]]; then
+      search_path=$download_path/$version_to_build
     else
-      echo "Download failed: $url_tail is not in the following, expected location:"
-      echo "$download_path"
+      search_path=$download_path/$url_tail
+    fi
+    if [ -f $search_path ] || [ -d $search_path ]; then
+      echo "Download succeeded. The $package_to_build source is in the following location:"
+      echo "$search_path"
+    else
+      echo "Download failed. The $package_to_build source is not in the following, expected location:"
+      echo "$search_path"
       echo "Aborting. [exit 110]"
       exit 110
     fi
@@ -320,7 +325,7 @@ download_if_necessary()
 unpack_if_necessary()
 {
   if [[ $fetch == "svn" || $fetch == "git" ]]; then
-    package_source_directory=$url_tail
+    package_source_directory=$version_to_build
   else
     printf "Unpacking $url_tail. \n"
     printf "Unpack command: tar xf $url_tail \n"

--- a/install_prerequisites/check_version.sh
+++ b/install_prerequisites/check_version.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# check_version.sh
+#
+# -- Verify whether an OpenCoarrays prerequisite meets the required minimum version number.
+#
+# OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
+# Copyright (c) 2015-2016, Sourcery, Inc.
+# Copyright (c) 2015-2016, Sourcery Institute
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+#    list of conditions and the following disclaimer in the documentation and/or
+#    other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of their contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Interpret the first argument as the package executable name
+package=$1
+# Interpret the second argument as the minimimum acceptable package version number
+minimum_version=$2
+# Interpret the third argument as indicating the desired verbosity
+verbose=$3
+
+this_script=`basename $0`
+
+usage()
+{
+    echo ""
+    echo " $this_script - Bash script for verifyin minimum version numbers for OpenCoarrays prerequisites"
+    echo ""
+    echo " Usage (optional arguments in square brackets): "
+    echo "      $this_script [<option>]"
+    echo "      $this_script  <package-name> <minimum-version-number> [--verbose]"
+    echo ""
+    echo " Options:"
+    echo "   --help, -h           Show this help message"
+    echo "   --list , -l          List the packages whose versions this script can verify"
+    echo ""
+    echo " Examples:"
+    echo ""
+    echo "   $this_script cmake 3.4.0"
+    echo "   $this_script flex 2.6.0 --verbose"
+    echo "   $this_script flex `./build flex --default --query-version`"
+    echo "   $this_script --help"
+    echo "   $this_script --list"
+    echo ""
+    echo "[exit 10]"
+    exit 10
+}  
+
+# Print usage information and exit if script is invoked without arguments or with --help or -h as the first argument
+if [ $# == 0 ]; then
+  usage | less
+  exit 20 
+
+elif [[ $1 == '--help' || $1 == '-h' ]]; then
+  usage | less
+  exit 30 
+
+elif [[ $1 == '--list' || $1 == '-l' ]]; then
+ echo "$this_script currently verifies minimum version numbers for the following OpenCoarrays prerequisites:"
+ echo "   cmake, flex, bison, m4"
+ exit 40 
+
+elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
+  # Print script copyright if invoked with -v, -V, or --version argument
+  cmake_project_line=`grep project ../CMakeLists.txt | grep VERSION`
+  text_after_version_keyword="${cmake_project_line##*VERSION}"
+  text_before_language_keyword="${text_after_version_keyword%%LANGUAGES*}"
+  opencoarrays_version=$text_before_language_keyword
+  echo "opencoarrays $opencoarrays_version"
+  echo ""
+  echo "OpenCoarrays prerequisite version verifier"
+  echo "Copyright (C) 2015-2016 Sourcery, Inc."
+  echo "Copyright (C) 2015-2016 Sourcery Institute"
+  echo ""
+  echo "OpenCoarrays comes with NO WARRANTY, to the extent permitted by law."
+  echo "You may redistribute copies of $this_script under the terms of the"
+  echo "BSD 3-Clause License.  For more information about these matters, see"
+  echo "http://www.sourceryinstitute.org/license.html"
+  echo ""
+fi
+
+package_version_header=`$1 --version | head -1`
+if [[ "$verbose" == "--verbose" ]]; then
+  echo $package_version_header
+fi
+
+# Extract the text after the final space:
+version=${package_version_header##* }
+major=${version%%.*}
+minor_patch=${version#*.}
+minor=${minor_patch%%.*}
+patch=${version##*.}
+if [[ "$verbose" == "--verbose" ]]; then
+  echo "$version = $major . $minor . $patch"
+fi
+
+# Extract the text after the final space:
+min_major=${minimum_version%%.*}
+min_minor_patch=${minimum_version#*.}
+min_minor=${min_minor_patch%%.*}
+min_patch=${minimum_version##*.}
+if [[ "$verbose" == "--verbose" ]]; then
+  echo "$minimum_version = $min_major . $min_minor . $min_patch"
+fi
+
+if [ "$(( major < min_major ))" -ne 0 ]; then
+  if [[ $verbose == "--verbose" ]]; then
+    echo "$major < $min_major"
+  fi
+  exit 10
+elif [[ $verbose == "--verbose" ]]; then
+  echo "$major >= $min_major"
+fi
+
+if [ "$(( minor < min_minor ))" -ne 0 ]; then
+  if [[ $verbose == "--verbose" ]]; then
+    echo "$minor < $min_minor"
+  fi
+  exit 20
+elif [[ $verbose == "--verbose" ]]; then
+  echo "$minor >= $min_minor"
+fi
+
+if [ "$(( patch < min_patch ))" -ne 0 ]; then
+  if [[ $verbose == "--verbose" ]]; then
+    echo "$patch < $min_patch"
+  fi
+  exit 30
+elif [[ $verbose == "--verbose" ]]; then
+  echo "$patch >= $min_patch"
+fi
+exit 0


### PR DESCRIPTION
Also bumping the minimum gfortran version to 5.3.0 and setting the default, script-installed gfortran so that it downloads the current 5 branch instead of the current trunk (6.0.0). 