### PR TITLE
Expand test matrix to include install.sh script and `build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,38 @@ env:
     - MPICH_BOT_URL_HEAD="https://github.com/sourceryinstitute/opencoarrays/files/64308/"
     - MPICH_BOT_URL_TAIL="mpich-3.2.yosemite.bottle.1.tar.gz"
     - OSX_PACKAGES="gcc cmake"
-    - BUILD_TYPE="CodeCoverage"
 
 matrix:
   include:
     - os: osx
+      env:
+        - BUILD_TYPE="CodeCoverage"
+    - os: osx
+      env:
+       - BUILD_TYPE="Release"
     - os: linux
       sudo: false
+      env:
+        - BUILD_TYPE="CodeCoverage"
+      cache:
+        directories:
+          - "$CACHE"
+          - "$HOME/.cache/pip"
+      addons:
+        apt:
+          sources:
+            - george-edison55-precise-backports
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - gfortran-5
+            - binutils
+            - cmake-data
+            - cmake
+    - os: linux
+      sudo: false
+      env:
+        - BUILD_TYPE="Release"
       cache:
         directories:
           - "$CACHE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,21 @@ env:
     - MPICH_DIR="$HOME/.local/usr/mpich"
     - MPICH_BOT_URL_HEAD="https://github.com/sourceryinstitute/opencoarrays/files/64308/"
     - MPICH_BOT_URL_TAIL="mpich-3.2.yosemite.bottle.1.tar.gz"
-    - OSX_PACKAGES="gcc cmake"
 
 matrix:
   include:
     - os: osx
       env:
         - BUILD_TYPE="CodeCoverage"
+          OSX_PACKAGES="gcc cmake"
     - os: osx
       env:
        - BUILD_TYPE="Release"
+         OSX_PACKAGES="gcc cmake"
+    - os: osx
+      env:
+       - BUILD_TYPE="InstallScript"
+         OSX_PACKAGES="gcc"
     - os: linux
       sudo: false
       env:
@@ -26,7 +31,6 @@ matrix:
       cache:
         directories:
           - "$CACHE"
-          - "$HOME/.cache/pip"
       addons:
         apt:
           sources:
@@ -45,7 +49,6 @@ matrix:
       cache:
         directories:
           - "$CACHE"
-          - "$HOME/.cache/pip"
       addons:
         apt:
           sources:
@@ -57,6 +60,17 @@ matrix:
             - binutils
             - cmake-data
             - cmake
+    - os: linux
+      sudo: false
+      env:
+        - BUILD_TYPE="InstallScript"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - gfortran-5
 
 before_install:
   - |
@@ -70,13 +84,12 @@ before_install:
       export CC=gcc-5
       $FC --version
       $CC --version
-      cmake --version
     fi
 
 install:
   - |
     if [[ $TRAVIS ]] && [[ "X$TRAVIS_OS_NAME" = "Xosx" ]]; then
-    brew update > /dev/null
+      brew update > /dev/null
 
       for pkg in $OSX_PACKAGES; do
         [[ "$(brew ls --versions $pkg)" ]] || brew install --force-bottle $pkg
@@ -84,59 +97,84 @@ install:
       done
       export FC=gfortran-5
       export CC=gcc-5
-      if ! [[ "$(brew ls --versions mpich)" ]]; then
+      if ! [[ "$(brew ls --versions mpich)" ]] && [[ "X$BUILD_TYPE" != "XInstallScript" ]]; then
         wget ${MPICH_BOT_URL_HEAD}${MPICH_BOT_URL_TAIL}
         brew install --force-bottle ${MPICH_BOT_URL_TAIL}
         if ! [[ "$(brew ls --versions mpich)" ]]; then
           brew install --force-bottle mpich
         fi
+        mpif90 --version
+        mpicc --version
+        cmake --version
+        export FC=mpif90
+        export CC=mpicc
+      elif [[ "X$BUILD_TYPE" = "XInstallScript" ]]; then # uninstall some stuff if present
+        [[ "$(brew ls --versions cmake)" ]] && brew rm cmake || true
+        [[ "$(brew ls --versions mpich)" ]] && brew rm mpich || true
+        [[ "$(brew ls --versions openmpi)" ]] && brew rm openmpi || true
       fi
-    else
+    elif [[ "X$BUILD_TYPE" != "XInstallScript" ]]; then # Ubuntu on Travis-CI, NOT testing install.sh
       if ! ( [[ -x "$HOME/.local/bin/mpif90" ]] && [[ -x "$HOME/.local/bin/mpicc" ]] ); then
         # mpich install not cached
-        if ( [[ $TRAVIS ]] && [[ "X$TRAVIS_BRANCH" == Xbranch-1.* ]] ); then
-          install_prerequisites/build mpich "$MPICH_VER" "$MPICH_DIR" 4
-        else
-          # install_prerequisites/build is broken as of 2015.12.09 / 9d2edbb0 on master
-          # argument parsing bug fixes haven't made it back into master yet...
-          wget "${MPICH_URL_HEAD}/${MPICH_URL_TAIL}"
-          mv "$MPICH_URL_TAIL" "$MPICH_DIR/.."
-          pushd "$MPICH_DIR/.."
-          tar -xzvf "$MPICH_URL_TAIL"
-          cd "${MPICH_URL_TAIL%.tar.gz}"
-          ./configure --prefix="$MPICH_DIR"
-          make -j 4
-          make install
-          popd
+        # could use install_prerequisites/build instead...
+        wget "${MPICH_URL_HEAD}/${MPICH_URL_TAIL}"
+        mv "$MPICH_URL_TAIL" "$MPICH_DIR/.."
+        pushd "$MPICH_DIR/.."
+        tar -xzvf "$MPICH_URL_TAIL"
+        cd "${MPICH_URL_TAIL%.tar.gz}"
+        ./configure --prefix="$MPICH_DIR"
+        make -j 4
+        make install
+        popd
+        for f in "$MPICH_DIR/bin/"*; do
+          if [[ -x "$f" ]]; then
+            ln -fs "$f" "$HOME/.local/bin/${f##*/}" && "${f##*/}" --version
           fi
-          for f in "$MPICH_DIR/bin/"*; do
-            if [[ -x "$f" ]]; then
-              ln -fs "$f" "$HOME/.local/bin/${f##*/}" && "${f##*/}" --version
-            fi
-          done
-        fi
+        done
       fi
-
-before_script:
-  - mpif90 --version
-  - export FC=mpif90
-  - mpicc --version
-  - export CC=mpicc
-  - cmake --version
+      mpif90 --version
+      mpicc --version
+      cmake --version
+      export FC=mpif90
+      export CC=mpicc
+    fi
 
 script:
-  - mkdir cmake-build
-  - cd cmake-build
-  - cmake -DCMAKE_INSTALL_PREFIX:PATH="$HOME/OpenCoarrays" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" ..
-  - make -j 4
-  - ctest --verbose
-  - make install
-  - cd ..
+  - |
+    if [[ "X$BUILD_TYPE" = "XInstallScript" ]]; then
+      export FC=gfortran-5
+      export CC=gcc-5
+      [[ -d "$HOME/opt" ]] || mkdir "$HOME/opt"
+      [[ -d "$HOME/bin" ]] || mkdir "$HOME/bin"
+      ln -fs "$(which gfortran-5)" "$HOME/bin/gfortran"
+      ln -fs "$(which gcc-5)" "$HOME/bin/gcc"
+      ln -fs "$(which g++-5)" "$HOME/bin/g++"
+      export PATH="$PATH:$HOME/bin"
+      yes | ./install.sh $HOME/opt/opencoarrays 4 > install.log &
+      install_sh_PID=$!
+      echo "install.log will be displayed after success or failure"
+      while ps -p $install_sh_PID > /dev/null; do
+        echo "Still working on installing opencoarrays and dependencies"
+        sleep 300 # prevent Travis-CI abort due to inactivity and excessive logging
+      done
+    else
+      mkdir cmake-build
+      cd cmake-build
+      cmake -DCMAKE_INSTALL_PREFIX:PATH="$HOME/OpenCoarrays" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" ..
+      make -j 4
+      ctest --verbose
+      make install
+      cd ..
+    fi
 
 after_success:
   - find . -name '*.gcno' -print
   - gcov-5 --version
   - bash <(curl -s https://codecov.io/bash) -x $(which gcov-5)
+  - cat install.log || true
+
+after_failure:
+  - cat install.log || true
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,6 +180,7 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/93dbafbdf76c1732a623
+      - https://webhooks.gitter.im/e/935231573bf1b9f2fe40
     on_success: change  # options: [always|never|change]
     on_failure: always
     on_start: always


### PR DESCRIPTION
Missing from this PR, i.e., still under development:

 - Clever managing which dependencies are pre-loaded through more expedient Travis-CI logic, when build scripts have not been touched, but building as much as we can when modified in the commit range being tested by Travis-CI
 - Testing car wrapper scripts after OpenCoarrays has been installed (This isn't done in any tests yet)

Additionally, `.travis.yml` is getting unwieldy and could benefit from being broken up into one or more shell scripts ( #101 )