### PR TITLE
Fix links, typos & formatting in markdown docs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,14 @@
-# Contributors to OpenCoarrays
+Contributors to OpenCoarrays
+============================
 
  - Alessandro Fanfarillo  <fanfarillo@ing.uniroma2.it>
  - Damian Rouson  <damian@rouson.net>
+ - Izaak Beekman  <http://izaakbeekman.com>
  - Daniel Carrera  <dcarrera@gmail.com>
  - Jeff Hammond  <jeff.science@gmail.com>
  - Tobias Burnus  <burnus@net-b.de>
+
+[I think we're missing a number of people here]:#
+[@naveen-rn?]:#
+[@raul-nasner?]:#
+[Others:]:#

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,11 @@
 Contributors to OpenCoarrays
 ============================
 
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/AUTHORS.pdf)
+
+Download this file as a PDF document
+[here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/AUTHORS.pdf).
+
  - Alessandro Fanfarillo  <fanfarillo@ing.uniroma2.it>
  - Damian Rouson  <damian@rouson.net>
  - Izaak Beekman  <http://izaakbeekman.com>
@@ -12,3 +17,6 @@ Contributors to OpenCoarrays
 [@naveen-rn?]:#
 [@raul-nasner?]:#
 [Others:]:#
+
+[Links]:#
+[pdf img]: https://img.shields.io/badge/PDF-AUTHORS.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/CAF_ABI.md
+++ b/CAF_ABI.md
@@ -5,6 +5,11 @@
 OpenCoarrays Application Binary Interface (ABI)
 ===============================================
 
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/CAF_ABI.pdf)
+
+Download this file as a PDF document
+[here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/CAF_ABI.pdf).
+
 * [To Do](#to-do)
 * [Implementation status](#implementation-status)
 * [Definitions and types](#definitions-and-types)
@@ -563,3 +568,4 @@ __TODO__:
 [Implementation status]: #implementation-status
 [Definitions and types]: #definitions-and-types
 [Provided functions]: #provided-functions
+[pdf img]: https://img.shields.io/badge/PDF-CAF_ABI.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/CAF_ABI.md
+++ b/CAF_ABI.md
@@ -2,100 +2,112 @@
 [For better viewing, including hyperlinks, read it online at            ]:#
 [https://github.com/sourceryinstitute/opencoarrays/blob/master/CAF_API.md]:#
 
-# OpenCoarrays Application Binary Interface (ABI) #
+OpenCoarrays Application Binary Interface (ABI)
+===============================================
 
-* [To Do]
-* [Implementation status]
-* [Definitions and types]
-* [Provided functions]
+* [To Do](#to-do)
+* [Implementation status](#implementation-status)
+* [Definitions and types](#definitions-and-types)
+* [Provided functions](#provided-functions)
 
 This document describes the OpenCoarrays application binary interface (ABI) through
 which a compiler accesses coarray functionality.  As such, the target audience for
 this document is compiler developers.  Most application developers need only write
 standard-conforming Fortran 2008 or 2015 and compile their code with the OpenCoarrays
-'caf' compiler wrapper without knowledge of the ABI.
+`caf` compiler wrapper without knowledge of the ABI.
 
 The actual function names in this document have a PREFIX in the source code to avoid
 name clashes.  The prefix can be vendor-specific.
 
-## <a name="to-do">To Do</a> ##
+To Do
+-----
 
-* Discuss the current draft
-* Add missing functions of the current gfortran implementation
-* Address the TODO items
-* Extend the functions to match a sensible set
-* Update the implementation status, especially for the ARMCI library
+* [ ] Discuss the current draft
+* [ ] Add missing functions of the current gfortran implementation
+* [ ] Address the TODO items
+* [ ] Extend the functions to match a sensible set
+* [ ] Update the implementation status, especially for the ARMCI library
 
-## <a name="implementation-status">Implementation status</a> ##
+Implementation status
+---------------------
 
 The library implementation in this directory should be ABI-compatible
-with the wording below, except for some "int errmsg_len" vs. size_t
+with the wording below, except for some `int errmsg_len` vs. `size_t`
 changes that have not yet been implemented.
 
-## <a name="definitions-and-types">Definitions and types</a> ##
+Definitions and types
+---------------------
 
-### 2.1  caf_token_t ###
+### 2.1  `caf_token_t` ###
 
-Typedef of type "void *" on the compiler side. Can be any data
+Typedef of type `void *` on the compiler side. Can be any data
 type on the library side.
 
-### 2.2  caf_register_t ###
+### 2.2  `caf_register_t` ###
 
 Type indicating which kind of coarray variable should be registered.
 
-    typedef enum caf_register_t {
-      CAF_REGTYPE_COARRAY_STATIC,
-      CAF_REGTYPE_COARRAY_ALLOC,
-      CAF_REGTYPE_LOCK_STATIC,
-      CAF_REGTYPE_LOCK_ALLOC,
-      CAF_REGTYPE_CRITICAL,
-      CAF_REGTYPE_EVENT_STATIC,
-      CAF_REGTYPE_EVENT_ALLOC
-    }
-    caf_register_t;
+```c
+typedef enum caf_register_t {
+  CAF_REGTYPE_COARRAY_STATIC,
+  CAF_REGTYPE_COARRAY_ALLOC,
+  CAF_REGTYPE_LOCK_STATIC,
+  CAF_REGTYPE_LOCK_ALLOC,
+  CAF_REGTYPE_CRITICAL,
+  CAF_REGTYPE_EVENT_STATIC,
+  CAF_REGTYPE_EVENT_ALLOC
+  }
+caf_register_t;
+```
 
-TODO:
+__TODO__:
   Check whether this set is complete and makes sense
 
 
-### 2.3  caf_token_t ###
+### 2.3  `caf_token_t` ###
 
 In terms of the processor, an opaque pointer, which is used to identify a
 coarray.  The exact content is implementation-defined by the library.
 
 ### 2.4  Stat values ###
 
-    #define STAT_UNLOCKED           0
-    #define STAT_LOCKED             1
-    #define STAT_LOCKED_OTHER_IMAGE 2
-    #define STAT_STOPPED_IMAGE      6000
+```c
+#define STAT_UNLOCKED           0
+#define STAT_LOCKED             1
+#define STAT_LOCKED_OTHER_IMAGE 2
+#define STAT_STOPPED_IMAGE      6000
+```
 
-TODO:
-  Define more, allow room for lib-specific values, update for TS18508.
+__TODO__:
+  Define more, allow room for lib-specific values, update for [TS18508].
   Do we need to take care of special vendor choices?
-  Note: Some values have to be such that they differ from certain other
+
+__Note__:
+  Some values have to be such that they differ from certain other
   values.
 
 
-## <a name="provided-functions">Provided functions</a> ##
+Provided functions
+------------------
 
 ### 3.1  Initialization function ###
 
-    void caf_init (int *argc, char ***argv)
+```c
+void caf_init (int *argc, char ***argv)
+```
 
 This function shall be called at startup of the program before the Fortran main
 program.  It takes as arguments the command-line arguments of the program. It is
 permitted to pass to NULL pointers as argument; if non-NULL, the library is
 permitted to modify the arguments.
 
-Arguments:
-    argc  intent(inout) An integer pointer with the number of arguments
-          passed to the program or NULL.
-    argv  intent(inout) A pointer to an array of strings with the
-          command-line arguments or NULL.
+| Argument	| `intent`	| description	|
+| ------	| ------	| ------	|
+| `argc`	| `inout`	| An integer pointer with the number of arguments passed to the program or NULL.	|
+| `argv`	| `inout`	| A pointer to an array of strings with the      command-line arguments or NULL.	|
 
-NOTE:
-  The function is modelled after the initialization function of the
+__Note__:
+  The function is modeled after the initialization function of the
   Message Passing Interface (MPI) specification.  Due to the way coarray
   registration (3.5) works, it might not be the first call to the libaray. If
   the main program is not written in Fortran and only a library uses coarrays,
@@ -103,7 +115,7 @@ NOTE:
   recommended that the library does not rely on the passed arguments and whether
   the call has been done.
 
-GCC:
+__GCC__:
   In gfortran, the function is generated when the Fortran main program is
   compiled with -fcoarray=lib; the call happens before the run-time library
   initialiation such that changes to the command-line arguments will be visible
@@ -112,305 +124,295 @@ GCC:
 
 ### 3.2  Finalization function ###
 
-     void caf_finish (void)
+```c
+void caf_finish (void)
+```
 
 This function shall be called at the end of the program to permit a graceful
 shutdown.
 
-NOTE:
+__Note__:
   It is recommended to add this call at the end of the Fortran main program and
-  when invoking STOP.  To ensure that the shutdown is also performed for
+  when invoking `STOP`.  To ensure that the shutdown is also performed for
   programs where this function is not explicitly invoked, for instance
-  non-Fortran programs or calls to the system's exit() function, the library can
+  non-Fortran programs or calls to the system's `exit()` function, the library can
   use a destructor function.  Note that programs can also be terminated using
-  the ERROR STOP statement, which is handled via its own library call.
+  the `ERROR STOP` statement, which is handled via its own library call.
 
-GCC:
+__GCC__:
   In gfortran, this function is called at the end of the Fortran main program and
-  when before the program stops with a STOP command, the respective file has been
-  compiled with the -fcoarray=lib option.
+  when before the program stops with a `STOP` command, the respective file has been
+  compiled with the `-fcoarray=lib` option.
 
 
 ### 3.3 Querying the image number ###
 
-    int caf_this_image (int distance)
+```c
+int caf_this_image (int distance)
+```
 
 This function returns the current image number, which is a positive number.
 
-Argument:
-  distance   As specified for the this_image intrinsic in TS18508. Shall be a
-             nonnegative number.
-NOTE:
-  If the Fortran intrinsic this_image() is invoked without an argument, which
-  is the only permitted form in Fortran 2008, the processer shall pass 0 as
-  first argument.
+| Argument	| description	|
+| ------	| ------	|
+| `distance`	| As specified for the `this_image` intrinsic in [TS18508]. Shall be a nonnegative number.	|
 
-GCC:
+__Note__:
+  If the Fortran intrinsic `this_image()` is invoked without an argument, which is the only permitted form in Fortran 2008, the processor shall pass 0 as first argument.
+
+__GCC__:
   (No special note.)
 
 
 
 ### 3.4 Querying the maximal number of images ###
 
-    int caf_num_images (int distance, int failed)
+```c
+int caf_num_images (int distance, int failed)
+```
 
 This function returns the number of images in the current team, if distance is 0
 or the number of images in the parent team at the specified distance. If failed
 is -1, the function returns the number of all images at the specified
-distance; if it is 0, the function returns the number of nonfailed images, and
+distance; if it is 0, the function returns the number of non-failed images, and
 if it is 1, it returns the number of failed images.
 
-Arguments:
-  distance  the distance from this image to the ancestor. Shall be positive.
-  failed    shall be -1, 0, or 1
+| Argument	| description	|
+| ------	| ------	|
+| `distance`	| the distance from this image to the ancestor. Shall be positive.	|
+| `failed`	| shall be -1, 0, or 1	|
 
-NOTE:
-  This function follows TS18508. If the num_image intrinsic has no arguments,
-  the processor shall pass distance=0 and failed=-1 to the function.
+__Note__:
+  This function follows [TS18508]. If the `num_image` intrinsic has no arguments,
+  the processor shall pass `distance = 0` and `failed = -1` to the function.
 
-GCC:
+__GCC__:
   (No special note.)
 
 
 
 ### 3.5 Registering coarrays ###
 
-    void *caf_register (size_t size, caf_register_t type, caf_token_t *token,
-                        int *stat, char *errmsg, int errmsg_len)
+```c
+void *caf_register (size_t size, caf_register_t type, caf_token_t *token, int *stat, char *errmsg, int errmsg_len)
+```
 
 Allocates memory for a coarray and creates a token to identify the coarray. The
-function is called for both coarrays with SAVE attribute and using an explicit
-ALLOCATE statement. If an error occurs and STAT is a NULL pointer, the function
+function is called for both coarrays with `SAVE` attribute and using an explicit
+`ALLOCATE` statement. If an error occurs and `STAT` is a `NULL` pointer, the function
 shall abort with printing an error message and starting the error termination.
-If no error occurs and STAT= is present, it shall be set to zero. Otherwise, it
+If no error occurs and `STAT=` is present, it shall be set to zero. Otherwise, it
 shall be set to a positive value and, if not-@code{NULL}, @var{ERRMSG} shall be
 set to a string describing the failure.  The function returns a pointer to the
-requested memory for the local image as a call to malloc would do.
+requested memory for the local image as a call to `malloc` would do.
 
-For CAF_REGTYPE_COARRAY_STATIC and CAF_REGTYPE_COARRAY_ALLOC, the passed size is
-the byte size requested. For CAF_REGTYPE_LOCK_STATIC, CAF_REGTYPE_LOCK_ALLOC
-and CAF_REGTYPE_CRITICAL it is the array size or one for a scalar.
+For `CAF_REGTYPE_COARRAY_STATIC` and `CAF_REGTYPE_COARRAY_ALLOC`, the passed size is
+the byte size requested. For `CAF_REGTYPE_LOCK_STATIC`, `CAF_REGTYPE_LOCK_ALLOC`
+and `CAF_REGTYPE_CRITICAL` it is the array size or one for a scalar.
 
-Arguments:
-  size   For normal coarrays, the byte size of the coarray to be
-         allocated; for lock types, the number of elements.
-  type   one of the caf_register_t types. Possible values:
-         CAF_REGTYPE_COARRAY_STATIC - for nonallocatable coarrays
-         CAF_REGTYPE_COARRAY_ALLOC - for allocatable coarrays
-         CAF_REGTYPE_LOCK_STATIC - for nonallocatable lock variables
-         CAF_REGTYPE_LOCK_ALLOC - for allocatable lock variables
-         CAF_REGTYPE_CRITICAL - for lock variables used for critical sections
+| Argument	| description	|
+| ------	| ------	|
+| `size`	| For normal coarrays, the byte size of the coarray to be allocated; for lock types, the number of elements.	|
+| `type`	| one of the `caf_register_t` types. Possible values: `CAF_REGTYPE_COARRAY_STATIC` - for nonallocatable coarrays `CAF_REGTYPE_COARRAY_ALLOC` - for allocatable coarrays `CAF_REGTYPE_LOCK_STATIC` - for nonallocatable lock variables `CAF_REGTYPE_LOCK_ALLOC` - for allocatable lock variables `CAF_REGTYPE_CRITICAL` - for lock variables used for critical sections	|
+| `token`	| `intent(out)` An opaque pointer identifying the coarray.	|
+| `stat`	| `intent(out)` For allocatable coarrays, stores the `STAT=`; may be `NULL`	|
+| `errmsg`	| intent(out) When an error occurs, this will be set to an error message; may be `NULL`	|
+| `errmgs_len`	| the buffer size of errmsg.	|
 
-  token  intent(out) An opaque pointer identifying the coarray.
-  stat   intent(out) For allocatable coarrays, stores the STAT=; may be NULL
-  errmsg intent(out) When an error occurs, this will be set to an error
-         message; may be NULL
-  errmgs_len the buffer size of errmsg.
+__TODO__:
 
-TODO:
-  - Check whether the locking should be handled like that and whether one needs
+  - [ ] Check whether the locking should be handled like that and whether one needs
   more, e.g. for locking types in DT?
-  - Check whether one needs an additional function for to register coarrays
+  - [ ] Check whether one needs an additional function for to register coarrays
   which are in static memory and used without memory allocation, i.e. just to
   register the address.
-  - Check whether we need an explicit SYNC ALL at the beginning of the main
+  - [ ] Check whether we need an explicit `SYNC ALL` at the beginning of the main
   program or whether we can do without.
-  - Does TS18508 require more for SAVE within teams or within blocks?
+  - [ ] Does [TS18508] require more for `SAVE` within teams or within blocks?
 
-NOTE:
-  Nonalloatable coarrays have to be registered prior use from remote images.
+__Note__:
+  Non-allocatable coarrays have to be registered prior use from remote images.
   In order to guarantee this, they have to be registered before the main
   program. This can be achieved by creating constructor functions.  When using
-  caf_register, also nonallocatable coarrays the memory is allocated and no
+  `caf_register`, also non-allocatable coarrays the memory is allocated and no
   static memory is used.
 
   For normal coarrays, the returned pointer is used for accesses on the local
   image. For lock types, the value shall only used for checking the allocation
   status. Note that for critical blocks, the locking is only required on one
   image; in the locking statement, the processor shall always pass always an
-  image index of one for critical-section lock variables (CAF_REGTYPE_CRITICAL).
+  image index of one for critical-section lock variables (`CAF_REGTYPE_CRITICAL`).
 
-GCC:
+__GCC__:
    (no special notes)
 
-TODO:
-   Change errmsg_len to size_t
+__TODO__:
+   Change `errmsg_len` to `size_t`
 
 
 
 ### 3.6  Deregistering coarrays ###
 
-    void caf_deregister (const caf_token_t *token, int *stat, char *errmsg,
-                         size_t errmsg_len)
+```c
+void caf_deregister (const caf_token_t *token, int *stat, char *errmsg, size_t errmsg_len)
+```
 
 Called to free the memory of a coarray; the processor calls this function for
 automatic and explicit deallocation.  In case of an error, this function shall
-fail with an error message, unless the STAT= variable is not null.
+fail with an error message, unless the `STAT=` variable is not null.
 
-Arguments:
-  token  intent(inout) An opaque pointer identifying the coarray.
-  stat   intent(out) For allocatable coarrays, stores the STAT=; may be NULL
-  errmsg intent(out) When an error occurs, this will be set to an error
-         message, may be NULL
-  errmgs_len the buffersize of errmsg.
+| Argument	| `intent`	| description	|
+| ------	| ------	| -----	|
+| `token`	| `inout`	| An opaque pointer identifying the coarray.	|
+| `stat`	| `out`	| For allocatable coarrays, stores the `STAT=`; may be `NULL`	|
+| `errmsg`	| `out`	| When an error occurs, this will be set to an error message, may be `NULL`	|
+| `errmgs_len`	| | the buffersize of `errmsg`.	|
 
-NOTE:
-  The implementation is permitted to set the token to NULL. However, it is
-  not required to do so.
-  For nonalloatable coarrays this function is never called.  If a cleanup is
-  required, it has to be handled via the finish, stop and error stop functions,
-  and via destructors.
+__Note__:
+  The implementation is permitted to set the token to `NULL`. However, it is not required to do so.
+  For nonalloatable coarrays this function is never called.  If a cleanup is required, it has to be handled via the finish, stop and error stop functions, and via destructors.
 
-GCC:
+__GCC__:
    (no special notes)
 
-TODO:
-   Change errmsg_len to size_t
+__TODO__:
+   Change `errmsg_len` to `size_t`
 
 
 ### 3.7  Sending data from a local image to a remote image ###
 
-   void caf_send (caf_token_t token, size_t offset, int image_index,
-                  gfc_descriptor_t *dest, caf_vector_t *dst_vector,
-                  gfc_descriptor_t *src, int dst_kind, int src_kind)
+```c
+void caf_send (caf_token_t token, size_t offset, int image_index,
+               gfc_descriptor_t *dest, caf_vector_t *dst_vector,
+               gfc_descriptor_t *src, int dst_kind, int src_kind)
+```
 
 Called to send a scalar, an array section or whole array from a local
-to a remote image identified by the image_index.
+to a remote image identified by the `image_index`.
 
-Arguments:
-  token  intent(in)  An opaque pointer identifying the coarray.
-  offset  By which amount of bytes the actual data is shifted compared to
-          the base address of the coarray.
-  image_index  The ID of the remote image; must be a positive number.
-  dest    intent(in) Array descriptor for the remote image for the bounds
-          and the size. The base_addr shall not be accessed.
-  dst_vector  intent(int)  If not NULL, it contains the vector subscript of
-          the destination array; the values are relative to the dimension
-          triplet of the dest argument.
-  src     intent(in) Array descriptor of the local array to be transferred
-          to the remote image
-  dst_kind Kind of the destination argument
-  src_kind Kind of the source argument
+| Argument	| description	|
+| ------	| ------	|
+| `token`	| `intent(in)`  An opaque pointer identifying the coarray.	|
+| `offset`	| By which amount of bytes the actual data is shifted compared to the base address of the coarray.	|
+| `image_index`	| The ID of the remote image; must be a positive number.	|
+| `dest`	| `intent(in)` Array descriptor for the remote image for the bounds and the size. The `base_addr` shall not be accessed.	|
+| `dst_vector`	| `intent(in)`  If not `NULL`, it contains the vector subscript of the destination array; the values are relative to the dimension triplet of the dest argument.	|
+| `src`	| `intent(in)` Array descriptor of the local array to be transferred to the remote image	|
+| `dst_kind`	| Kind of the destination argument	|
+| `src_kind`	| Kind of the source argument	|
 
-NOTE:
-  It is permitted to have image_id equal the current image; the memory of the
+__Note__:
+  It is permitted to have `image_id` equal the current image; the memory of the
   send-to and the send-from might (partially) overlap in that case. The
   implementation has to take care that it handles this case. Note that the
   assignment of a scalar to an array is permitted. In addition, the library has
   to handle numeric-type conversion and for strings, padding and different
-  character kinds.
+  `character` kinds.
 
-GCC:
-  Currently, it uses gfortran's private array descriptor. A change to TS29113's
+__GCC__:
+  Currently, it uses gfortran's private array descriptor. A change to [TS29113]'s
   array descriptor is planned; when that's done, the additional kind arguments
   will be removed.
-  Note that the kind arguments permit to distiniguish the character kinds and
-  real/complex kinds 10 and 16, which have the same byte size.
+  Note that the kind arguments permit to distiniguish the `character` kinds and
+  `real`/`complex` kinds 10 and 16, which have the same byte size.
 
 
-TODO FOR SEND*:
-  - Wait is missing
-  - Assignment to an address instead of using a token, to handle
-    caf[i]%allocatable%alloc_array(:,:) = ...
+__TODO__ `FOR SEND*`:
+
+  - [ ] Wait is missing
+  - [ ] Assignment to an address instead of using a token, to handle
+    `caf[i]%allocatable%alloc_array(:,:) = ...`
     Or some other means to handle those.
-  - Image index: How to handle references to other TEAMS?
+  - [ ] Image index: How to handle references to other TEAMS?
 
-OTHER TODOs:
-3.x TODO: Handle GET and remote-to-remote communication
-3.y TODO: Handle ATOMIC, LOCK, CRITICAL
-3.z TODO Teams and error recovery
+__OTHER TODOs__:
 
-
+- [ ] 3.x TODO: Handle `GET` and remote-to-remote communication
+- [ ] 3.y TODO: Handle `ATOMIC`, `LOCK`, `CRITICAL`
+- [ ] 3.z TODO Teams and error recovery
 
 ### 3.8  Getting data from a remote image ###
 
-   void caf_get_desc (caf_token_t token, size_t offset,
-                      int image_index, gfc_descriptor_t *src,
-		      caf_vector_t *src_vector, gfc_descriptor_t *dest,
-                      int src_kind, int dst_kind)
+```c
+void caf_get_desc (caf_token_t token, size_t offset,
+                   int image_index, gfc_descriptor_t *src,
+                   caf_vector_t *src_vector, gfc_descriptor_t *dest,
+                   int src_kind, int dst_kind)
+```
 
 Called to get an array section or whole array from a a remote,
-image identified by the image_index.
+image identified by the `image_index`.
 
-Arguments:
-  token  intent(in)  An opaque pointer identifying the coarray.
-  offset  By which amount of bytes the actual data is shifted compared to
-          the base address of the coarray.
-  image_index  The ID of the remote image; must be a positive number.
-  dest     intent(out) Array descriptor of the local array to which the data
-          will be transferred
-  src    intent(in) Array descriptor for the remote image for the bounds
-          and the size. The base_addr shall not be accessed.
-  src_vector  intent(int)  If not NULL, it contains the vector subscript of
-          the destination array; the values are relative to the dimension
-          triplet of the dest argument.
-  dst_kind Kind of the destination argument
-  src_kind Kind of the source argument
+| Argument	| description	|
+| ------	| ------	|
+| `token`	| `intent(in)` An opaque pointer identifying the coarray.	|
+| `offset`	| By which amount of bytes the actual data is shifted compared to the base address of the coarray.	|
+| `image_index`	| The ID of the remote image; must be a positive number.	|
+| `dest`	| `intent(out)` Array descriptor of the local array to which the data will be transferred	|
+| `src`	| `intent(in)` Array descriptor for the remote image for the bounds and the size. The `base_addr` shall not be accessed.
+| `src_vector`	| `intent(int)` If not `NULL`, it contains the vector subscript of the destination array; the values are relative to the dimension triplet of the dest argument.	|
+| `dst_kind`	| Kind of the destination argument	|
+| `src_kind`	| Kind of the source argument	|
 
-NOTE:
-  It is permitted to have image_id equal the current image; the memory of the
+__Note__:
+  It is permitted to have `image_id` equal the current image; the memory of the
   send-to and the send-from might (partially) overlap in that case. The
   implementation has to take care that it handles this case. Note that the
   library has to handle numeric-type conversion and for strings, padding
-  and different character kinds.
+  and different `character` kinds.
 
-GCC:
-  Currently, it uses gfortran's private array descriptor. A change to TS29113's
+__GCC__:
+  Currently, it uses gfortran's private array descriptor. A change to [TS29113]'s
   array descriptor is planned; when that's done, the additional kind arguments
   will be removed.
-  Note that the kind arguments permit to distiniguish the character kinds and
-  real/complex kinds 10 and 16, which have the same byte size.
+  Note that the kind arguments permit to distinguish the `character` kinds and
+  `real`/`complex` kinds 10 and 16, which have the same byte size.
 
 
 ### 3.9  Sending data between remote images ###
 
-   void caf_sendget (caf_token_t dst_token, size_t dst_offset,
-                     int dst_image_index, gfc_descriptor_t *dest,
-                     caf_vector_t *dst_vector, caf_token_t src_token,
-                     size_t src_offset, int src_image_index,
-                     gfc_descriptor_t *src, caf_vector_t *src_vector,
-                     int dst_kind, int src_kind)
+```c
+void caf_sendget (caf_token_t dst_token, size_t dst_offset,
+                  int dst_image_index, gfc_descriptor_t *dest,
+                  caf_vector_t *dst_vector, caf_token_t src_token,
+                  size_t src_offset, int src_image_index,
+                  gfc_descriptor_t *src, caf_vector_t *src_vector,
+                  int dst_kind, int src_kind)
+```
 
 Called to send a scalar, an array section or whole array from a remote image
-identified by the src_image_index to a remote image identified by the
-dst_image_index.
+identified by the `src_image_index` to a remote image identified by the
+`dst_image_index`.
 
-Arguments:
-  dst_token  intent(in)  An opaque pointer identifying the destination coarray.
-  dst_offset  By which amount of bytes the actual data is shifted compared to
-          the base address of the destination coarray.
-  dst_image_index  The ID of the destination remote image; must be a positive
-          number.
-  dest    intent(in) Array descriptor for the destination remote image for
-          the bounds and the size. The base_addr shall not be accessed.
-  dst_vector  intent(int)  If not NULL, it contains the vector subscript of
-          the destination array; the values are relative to the dimension
-          triplet of the dest argument.
-  src_token  intent(in)  An opaque pointer identifying the source coarray.
-  src_offset  By which amount of bytes the actual data is shifted compared to
-          the base address of the source coarray.
-  src_image_index  The ID of the source remote image; must be a positive number.
-  src     intent(in) Array descriptor of the local array to be transferred
-          to the remote image
-  src_vector     intent(in) Array descriptor of the local array to be transferred
-          to the remote image
-  dst_kind Kind of the destination argument
-  src_kind Kind of the source argument
+| Argument	| description	|
+| ------	| ------	|
+| `dst_token`	| `intent(in)`  An opaque pointer identifying the destination coarray.	|
+| `dst_offset`	| By which amount of bytes the actual data is shifted compared to the base address of the destination coarray.	|
+| `dst_image_index`	| The ID of the destination remote image; must be a positive number.	|
+| `dest`	| `intent(in)` Array descriptor for the destination remote image for the bounds and the size. The `base_addr` shall not be accessed.	|
+| `dst_vector`	| `intent(int)`  If not NULL, it contains the vector subscript of the destination array; the values are relative to the dimension triplet of the dest argument.	|
+| `src_token`	| `intent(in)` An opaque pointer identifying the source coarray.	|
+| `src_offset`	| By which amount of bytes the actual data is shifted compared to the base address of the source coarray.	|
+| `src_image_index`	| The ID of the source remote image; must be a positive number.	|
+| `src`	| `intent(in)` Array descriptor of the local array to be transferred to the remote image	|
+| `src_vector`	| `intent(in)` Array descriptor of the local array to be transferred to the remote image	|
+| `dst_kind`	| Kind of the destination argument	|
+| `src_kind`	| Kind of the source argument	|
 
-NOTE:
-  It is permitted to have image_id equal the current image; the memory of the
+__Note__:
+  It is permitted to have `image_id` equal the current image; the memory of the
   send-to and the send-from might (partially) overlap in that case. The
   implementation has to take care that it handles this case. Note that the
   assignment of a scalar to an array is permitted. In addition, the library has
   to handle numeric-type conversion and for strings, padding and different
-  character kinds.
+  `character` kinds.
 
-GCC:
-  Currently, it uses gfortran's private array descriptor. A change to TS29113's
+__GCC__:
+  Currently, it uses gfortran's private array descriptor. A change to [TS29113]'s
   array descriptor is planned; when that's done, the additional kind arguments
   will be removed.
-  Note that the kind arguments permit to distiniguish the character kinds and
-  real/complex kinds 10 and 16, which have the same byte size.
+  Note that the kind arguments permit to distinguish the `character` kinds and
+  `real`/`complex` kinds 10 and 16, which have the same byte size.
 
 
 
@@ -418,144 +420,145 @@ GCC:
 
 ### 3.10.1  All-Image Barrier ###
 
-   void caf_sync_all (int *stat, char *errmsg, size_t errmsg_len)
+```c
+void caf_sync_all (int *stat, char *errmsg, size_t errmsg_len)
+```
 
 Barrier which waits for all other images, pending asynchronous communication
 and other data transfer.
 
-Arguments:
-  stat  Status variable, if NULL, failures are fatal. If nonnull, assigned 0
-        on success, and a stat code (cf. 2.3) in case of an error.
-  errmsg  If not NULL: Ignored unless stat is present; unmodified when
-          successful, otherwise, an error message is copied into the variable.
-  errmsg_len  Maximal length of the error string, which is not '\0' terminated.
-          The string should be padded by blanks.
+| Argument	| description	|
+| ------	| ------	|
+| `stat`	| Status variable, if `NULL`, failures are fatal. If non-null, assigned 0 on success, and a stat code (cf. 2.3) in case of an error.	|
+| `errmsg`	| If not NULL: Ignored unless stat is present; unmodified when successful, otherwise, an error message is copied into the variable.	|
+| `errmsg_len`	| Maximal length of the error string, which is not '\0' terminated. The string should be padded by blanks.	|
 
-Note:
+__Note__:
   For portability, consider only using 7bit ASCII characters in the error
   message.
-GCC:
+
+__GCC__:
   Implemented in GCC 4.x using an int argument for the length.
-  Currently, size_t is not implemented.
+  Currently, `size_t` is not implemented.
 
 
 
 ### 3.10.2  Barrier for Selected Images ###
 
-   void sync_images (int count, int images[], int *stat,
-                     char *errmsg, size_t errmsg_len)
+```c
+void sync_images (int count, int images[], int *stat,
+                  char *errmsg, size_t errmsg_len)
+```
 
-Arguments:
-  count Size of the array "images"; has value -1 for 'sync images(*)' and
-        value 0 for a zero-sized array.
-  image  list of images to be synced with.
-  stat  Status variable, if NULL, failures are fatal. If nonnull, assigned 0
-        on success, and a stat code (cf. 2.3) in case of an error.
-  errmsg  If not NULL: Ignored unless stat is present; unmodified when
-          successful, otherwise, an error message is copied into the variable.
-  errmsg_len  Maximal length of the error string, which is not '\0' terminated.
-          The string should be padded by blanks.
+| Argument	| description	|
+| ------	| ------	|
+| `count`	| Size of the array "images"; has value -1 for `sync images(*)` and value 0 for a zero-sized array.	|
+| `image`	| list of images to be synced with.	|
+| `stat`	| Status variable, if NULL, failures are fatal. If non-null, assigned 0 on success, and a stat code (cf. 2.3) in case of an error.	|
+| `errmsg`	| If not `NULL`: Ignored unless stat is present; unmodified when successful, otherwise, an error message is copied into the variable.	|
+| `errmsg_len`	| Maximal length of the error string, which is not `\0` terminated. The string should be padded by blanks.	|
 
-Note:
+__Note__:
   For portability, consider only using 7bit ASCII characters in the error
-  message. Note that the list can contain also the ID of this image or can be
-  an empty set. Example use is that image 1 syncs with all others (i.e "sync
-  images(*)") and the others sync only with that image ("sync image(1)"). Or
-  for point-to point communication (sync image([left_image, right_image]).
+  message. Note that the list can contain also the ID of `this_image` or can be
+  an empty set. Example use is that image 1 syncs with all others (i.e `sync images(*)`) and the others sync only with that image (`sync image(1)`). Or
+  for point-to point communication (`sync image([left_image, right_image]`).
 
-GCC:
+__GCC__:
   Implemented in GCC 4.x using an int argument for the error-string length.
-  Currently, size_t is not implemented.
+  Currently, `size_t` is not implemented.
 
 ### 3.11  Error abort ###
 
-   void error_stop_str (const char *string, int32_t str_len)
-   void error_stop (int32_t exit_error_code)
+```c
+void error_stop_str (const char *string, int32_t str_len);
+void error_stop (int32_t exit_error_code)
+```
 
-TODO
-  - Fix this description by filling-in the missing bits
-  - STOP vs ERROR STOP handling. Currently, STOP calls "finalize" and then the
-    normal STOP while for ERROR STOP directly calls the library
-  - F2008 requires that one prints the raised exceptions with STOP and ERROR
-    STOP. libgfortran's STOP and ERROR STOP do so - the current implementation
-    for ERROR STOP does not.
+__TODO__
+
+  - [ ] Fix this description by filling-in the missing bits
+  - [ ] `STOP` vs `ERROR STOP` handling. Currently, `STOP` calls `finalize` and then the
+    normal `STOP` while for `ERROR STOP` directly calls the library
+  - [ ] F2008 requires that one prints the raised exceptions with `STOP` and `ERROR
+    STOP`. libgfortran's `STOP` and `ERROR STOP` do so - the current implementation
+    for `ERROR STOP` does not.
 
 
 ### 3.11  Locking and unlocking ###
 
 #### 3.11.1  Locking a lock variable ####
 
-   void caf_lock (caf_token_t token, size_t index, int image_index,
-                  int *aquired_lock, int *stat, char *errmsg,
-                  int errmsg_len)
+```c
+void caf_lock (caf_token_t token, size_t index, int image_index,
+               int *aquired_lock, int *stat, char *errmsg,
+               int errmsg_len)
+```
 
 Acquire a lock on the given image on a scalar locking variable or for the
-given array element for an array-valued variable. If the aquired_lock
-is NULL, the function return after having obtained the lock. If it is
-nonnull, the result is is assigned the value true (one) when the lock could be
+given array element for an array-valued variable. If the `acquired_lock`
+is `NULL`, the function return after having obtained the lock. If it is
+non-null, the result is is assigned the value true (one) when the lock could be
 obtained and false (zero) otherwise.  Locking a lock variable which has already
 been locked by the same image is an error.
 
-Arguments:
-  token   intent(in) An opaque pointer identifying the coarray.
-  index   Array index; first array index is 0. For scalars, it is
-          always 0.
-  image_index  The ID of the remote image; must be a positive
-          number.
-  aquired_lock   intent(out) If not NULL, it returns whether lock
-          could be obtained
-  stat    intent(out) For allocatable coarrays, stores the STAT=;
-          may be NULL
-  errmsg  intent(out) When an error occurs, this will be set to
-          an error message; may be NULL
-  errmsg_len  the buffer size of errmsg.
+| Argument	| arguments	|
+| ------	| ------	|
+| `token`	| `intent(in)` An opaque pointer identifying the coarray.	|
+| `index`	| Array index; first array index is 0. For scalars, it is always 0.	|
+| `image_index`	| The ID of the remote image; must be a positive number.	|
+| `aquired_lock`	| `intent(out)` If not NULL, it returns whether lock could be obtained	|
+| `stat`	| `intent(out)` For allocatable coarrays, stores the `STAT=`; may be NULL	|
+| `errmsg`	| intent(out) When an error occurs, this will be set to an error message; may be NULL	|
+| `errmsg_len`	| the buffer size of errmsg.	|
 
-Note:
+__Note__:
   This function is also called for critical sections; for those, the array index
   is always zero and the image index is one.  Libraries are permitted to use other
   images for critical-section locking variables.
 
-GCC:
+__GCC__:
    (no special notes)
 
-TODO:
-   Change errmsg_len to size_t
+__TODO__:
+   Change `errmsg_len` to `size_t`
 
 
 #### 3.11.2  Unlocking a lock variable ####
 
-   void caf_unlock (caf_token_t token, size_t index, int image_index,
-                    int *stat, char *errmsg, int errmsg_len)
+```c
+void caf_unlock (caf_token_t token, size_t index, int image_index,
+                 int *stat, char *errmsg, int errmsg_len)
+```
 
 Release a lock on the given image on a scalar locking variable or for the
 given array element for an array-valued variable. Unlocking a lock variable
 which is unlocked or has been locked by a different image is an error.
 
-Arguments:
-  token   intent(in) An opaque pointer identifying the coarray.
-  index   Array index; first array index is 0. For scalars, it is
-          always 0.
-  image_index  The ID of the remote image; must be a positive
-          number.
-  stat    intent(out) For allocatable coarrays, stores the STAT=;
-          may be NULL
-  errmsg  intent(out) When an error occurs, this will be set to
-          an error message; may be NULL
-  errmsg_len  the buffer size of errmsg.
+| Argument	| description	|
+| ------	| ------	|
+| `token`	| `intent(in)` An opaque pointer identifying the coarray.	|
+| `index`	| Array index; first array index is 0. For scalars, it is always 0.	|
+| `image_index`	| The ID of the remote image; must be a positive number.	|
+| `stat`	| `intent(out)` For allocatable coarrays, stores the `STAT=`; may be `NULL`	|
+| `errmsg`	| `intent(out)` When an error occurs, this will be set to an error message; may be `NULL`	|
+| `errmsg_len`	| the buffer size of `errmsg`.	|
 
-Note:
+__Note__:
   This function is also called for critical sections; for those, the array index
   is always zero and the image index is one.  Libraries are permitted to use other
   images for critical-section locking variables.
 
-GCC:
+__GCC__:
    (no special notes)
 
-TODO:
-   Change errmsg_len to size_t
+__TODO__:
+   Change `errmsg_len` to `size_t`
 
 [Hyperlinks]:#
 
+[TS29113]: ftp://ftp.nag.co.uk/sc22wg5/n1901-n1950/n1942.pdf
+[TS18508]: http://isotc.iso.org/livelink/livelink?func=ll&objId=17288706&objAction=Open
 [To Do]: #to-do
 [Implementation status]: #implementation-status
 [Definitions and types]: #definitions-and-types

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,55 +1,108 @@
-# Contribution procedure
+<a name="top"> </a>
 
-This document describes several pieces of information required for
-a contribution of code to OpenCoarrays to be approved.
+Contributing to OpenCoarrays
+============================
+
+- [Reporting Defects](#reporting-defects)
+- [Requesting Enhancements](#requesting-enhancements)
+- [Helping Out](#helping-out)
+  - [Outside Contributors](#outside-contributors)
+- [OpenCoarrays Branches](#opencoarrays-branches)
+  - [Master](#master)
+  - [Devel](#devel)
+
+Reporting Defects
+-----------------
+
+If you encounter problems during the course of [Installing] OpenCoarrays or [using OpenCoarrays], please take the following actions:
+
+ 1. Search the [issues] page (including [closed issues]) to see if anyone has encountered the same problem. If so add your experience to that thread.
+ 2. Search the [mailing list] to see if the issue has been discussed there.
+ 3. If unable to resolve the problem, please file a [new issue] and be sure to include the following information:
+   - Fortran and companion C compiler, including version number, being used with OpenCoarrays
+   - Communication library being used e.g., OpenMPI, MVAPICH or GASNet and the version number
+   - Open Coarrays version number, or if building from `master`, commit SHA (`caf --version`)
+   - Conditions required to reproduce the problem:
+     - OS
+     - Type of machine/hardware the code is running on
+     - Number of MPI ranks/processing elements/coarray images being run on
+     - How the code was compiled, including all flags and commands
+     - Minimal reproducer code (a few lines) required to trigger the bug
+  4. Any help you can provide diagnosing, isolating and fixing the problem is appreciated! Please see the [helping out] section for more information.
+
+Requesting Enhancements
+-----------------------
+
+If you would like OpenCoarrays to support a new communication library, OS, or have any other suggestions for its improvement, please take the following action:
+
+ 1. Search the [issues] page and [mailing list] to see if the feature or enhancement has already been requested.
+ 2. If not, please file a [new issue], and clearly explain your proposed enhancement.
+ 3. If you are able to help out in the implementation or testing of the proposed feature, please see the [helping out] section of this document.
+
+Helping Out
+-----------
+
+Thank you for your interest in contributing to OpenCoarrays! Your help is very appreciated! Below are some tips and guidelines to get started.
+
+### Outside Contributors ###
+
+Here is a checklist to help you get started contributing to OpenCoarrays and walk you through the process:
+
+ - [ ] Take a look at the [issues] page. Make sure that you're not about to duplicate someone else's work.
+ - [ ] Post a [new issue] discussing the changes you're proposing to implement; whether bug fix(es) or enhancement(s)/feature request(s)--or give us a heads up that you are going to start work on [an open issue].
+ - [ ] Please [Fork] the [OpenCoarrays repo] to your private repository.
+ - [ ] Next [Create a branch] and make sure to include the issue number(s) in the branch name, for example: `issue-53-fix-install-dir-logic` or `fix-typo-#23`
+ - [ ] Configure your local repository with the whitespace settings (and git hooks to enforce these) by running `./developer-scripts/setup-git.sh`. (Add the `--global` flag to this script to use these settings across all your new repositories, or newly cloned repositories.)  Pull requests introducing errant spaces and non-printing characters will not be accepted until these problems are addressed.
+ - [ ] Make your changes and commit them to your local repository, following these guidelines:
+   - [ ] Each commit should be a logically atomic, self-consistent, cohesive set of changes.
+   - [ ] The code should compile and pass all tests after each commit.
+   - [ ] The [commit message] should follow [these guidelines]:
+     - [ ] First line is directive phrase, starting with a capitalized imperative verb, and is no longer than 50 characters summarizing your commit
+     - [ ] Next line, if necessary is blank
+     - [ ] Following lines are all wrapped at 72 characters and can include additional paragraphs, bulleted lists, etc.
+     - [ ] Use [Github keywords] where appropriate, to indicate the commit resolves an open issue.
+ - [ ] Please do you best to keep a [clean and coherent history]. `git add -p ...`, `git commit --amend` and `git rebase --interactive <root-ref>` can be helpful to rework your commits into a cleaner, clearer state.
+ - [ ] Next, [open up a pull request] where the base branch is [`master`] or [`devel`] as appropriate
+ - [ ] Please be patient and responsive to requests and comments from SourceryInstitute (SI) team members. You may be asked to amend or otherwise alter commits, or push new commits to your branch.
+ - [ ] Make sure that all the automated [Travis-CI tests] pass
+ - [ ] Sign the [Contributor License Agreement (CLA)] by clicking the "details" link to the right of the `licence/cla` check and following the directions on the CLA assistant webpage
+
+OpenCoarrays Branches
+---------------------
+
+OpenCoarrays uses the [Github flow] workflow. There are [a number of resources] available to learn about the [Github flow] workflow, including a [video]. The gist of it is that the `master` branch is always deployable and deployed. The means at anytime, a new tagged release could be shipped using the `master` branch. For major changes that introduce experimental, or disruptive changes, we have a semi-stable `devel` branch.
+
+### Master ###
+
+The `master` branch should remain in pristine, stable condition all of the time. Any changes are applied atomically via pull requests. It should be assumed that customers are using the code on this branch, and great care should be taken to ensure its stability. Most bug fixes and incremental improvements will get merged into the `master` branch first, and then also the `devel` branch.
 
 
-# Pull requests
+### Devel ###
 
-We accept pull requests on the GitHub repository.
-Please follow the procedure explained at
-https://help.github.com/articles/using-pull-requests/.
+This is the development branch, akin to GCC's `trunk`. Both of `devel` and `master` branches are protected, but `devel` will eventually be merged into `master` when the next major release happens, but until then it is a stable, forward looking branch where experimental features and major changes or enhancements may be applied and tested. Just as with `master` all changes are applied atomically as pull requests.
 
-Remember to use the following command
-
-git commit --signoff
-
-in order to accept the Developer Certificate of Origin (below).
-
-
-# Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-660 York Street, Suite 102,
-San Francisco, CA 94110 USA
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
- 1. The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
- 2. The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
- 3.  The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
- 4. I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
+[Links]: #
+[video]: https://youtu.be/EwWZbyjDs9c?list=PLg7s6cbtAD17uAwaZwiykDci_q3te3CTY
+[a number of resources]: http://scottchacon.com/2011/08/31/github-flow.html
+[Github flow]: https://guides.github.com/introduction/flow/
+[Travis-CI tests]: https://travis-ci.org/sourceryinstitute/opencoarrays/pull_requests
+[Contributor License Agreement (CLA)]: https://cla-assistant.io/sourceryinstitute/opencoarrays
+[`master`]: https://github.com/sourceryinstitute/opencoarrays
+[`devel`]: https://github.com/sourceryinstitute/opencoarrays/tree/devel
+[open up a pull request]: https://github.com/sourceryinstitute/opencoarrays/compare
+[clean and coherent history]: https://www.reviewboard.org/docs/codebase/dev/git/clean-commits/
+[Github keywords]: https://help.github.com/articles/closing-issues-via-commit-messages/#closing-an-issue-in-a-different-repository
+[commit message]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
+[these guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[an open issue]: https://github.com/sourceryinstitute/opencoarrays/issues
+[Create a branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
+[OpenCoarrays repo]: https://github.com/sourceryinstitute/opencoarrays#fork-destination-box
+[Pull Request]: https://help.github.com/articles/using-pull-requests/
+[Fork]: https://help.github.com/articles/fork-a-repo/
+[helping out]: #helping-out
+[closed issues]: https://github.com/sourceryinstitute/opencoarrays/issues?q=is%3Aissue+is%3Aclosed
+[Installing]: ./INSTALLING.md
+[issues]: https://github.com/sourceryinstitute/opencoarrays/issues
+[mailing list]: https://groups.google.com/forum/#!forum/opencoarrays
+[using OpenCoarrays]: ./GETTING_STARTED.md
+[new issue]: https://github.com/sourceryinstitute/opencoarrays/issues/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 Contributing to OpenCoarrays
 ============================
 
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/CONTRIBUTING.pdf)
+
+Download this file as a PDF document
+[here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/CONTRIBUTING.pdf).
+
 - [Reporting Defects](#reporting-defects)
 - [Requesting Enhancements](#requesting-enhancements)
 - [Helping Out](#helping-out)
@@ -106,3 +111,4 @@ This is the development branch, akin to GCC's `trunk`. Both of `devel` and `mast
 [mailing list]: https://groups.google.com/forum/#!forum/opencoarrays
 [using OpenCoarrays]: ./GETTING_STARTED.md
 [new issue]: https://github.com/sourceryinstitute/opencoarrays/issues/new
+[pdf img]: https://img.shields.io/badge/PDF-CONTRIBUTING.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,41 +1,43 @@
+<a name="top"> </a>
+
 [This document is formatted with GitHub-Flavored Markdown.                       ]:#
 [For better viewing, including hyperlinks, read it online at                     ]:#
 [https://github.com/sourceryinstitute/opencoarrays/blob/master/GETTING_STARTED.md]:#
 
-# [Getting Started](#getting-started) #
+Getting Started
+===============
 
 * [The caf compiler wrapper]
 * [A sample basic workflow]
 * [An advanced workflow]
 
-<a name="the-caf-compiler-wrapper">
-## The caf compiler wrapper ##
-</a>
+The caf compiler wrapper
+--------------------------
 
-The preferred method for compiling a CAF program is by invoking the "caf" bash script
-that the OpenCoarrays CMake scripts install in the "bin" subdirectory of the installation
+The preferred method for compiling a CAF program is by invoking the `caf` bash script
+that the OpenCoarrays CMake scripts install in the `bin` subdirectory of the installation
 path. This is an experimental script with limited but useful capabilities that will
 grow over time.  Please submit bug reports and feature requests via our [Issues] page.
 
-The "caf" script liberates the source code and workflow from explicit dependence on the
+The `caf` script liberates the source code and workflow from explicit dependence on the
 underlying compiler and communication library in the following ways:
 
-1. With an OpenCoarrays-aware (OCA) CAF compiler, the "caf" script passes the unmodified
+1. With an OpenCoarrays-aware (OCA) CAF compiler, the `caf` script passes the unmodified
    source code to the underlying compiler with the necessary arguments for building a
-   CAF program, embedding the paths to OpenCoarrays libraries (e.g., libcaf_mpi.a) installed
-   in the "lib" subdirectory of the OpenCoarrays installation path.  The "caf" script also
-   embeds the path to the relevant module file in the "mod" subdirectory of the installation
-   path (e.g., opencoarrays.mod).  This supports use association with module entities via
-   ``use opencoarrays``.
-2. With a non-CAF compiler (including gfortran 4.9), "caf" supports a subset of CAF by
+   CAF program, embedding the paths to OpenCoarrays libraries (e.g., `libcaf_mpi.a`) installed
+   in the `lib` subdirectory of the OpenCoarrays installation path.  The `caf` script also
+   embeds the path to the relevant module file in the `mod` subdirectory of the installation
+   path (e.g., `opencoarrays.mod`).  This supports use association with module entities via
+   `use opencoarrays`.
+2. With a non-CAF compiler (including gfortran 4.9), `caf` supports a subset of CAF by
    replacing CAF statements with calls to procedures in the [opencoarrays module] before
    passing the source code to the compiler.
 
-When using GCC 4.9, we recommend using the `use` statement's "only" clause to
+When using GCC 4.9, we recommend using the `use` statement's `only` clause to
 avoid inadvertent procedure name clashes between OpenCoarrays procedures and their
-GCC counerparts.  For example, use "use opencoarrays, only : co_reduce".
+GCC counterparts.  For example, use `use opencoarrays, only : co_reduce`.
 
-With a non-OCA and OCA CAF compilers, the extensions that "caf" imports include the collective
+With a non-OCA and OCA CAF compilers, the extensions that `caf` imports include the collective
 subroutines proposed for Fortran 2015 in the draft Technical Specification [TS 18508]
 _Additional Parallel Features in Fortran_.
 
@@ -44,16 +46,16 @@ For example, a non-OCA CAF compiler, such as the Cray or Intel compilers, might 
 program's coarray square-bracket syntax, while OpenCoarrays supports the same program's calls to
 collective subroutine such as `co_sum` and `co_reduce`.
 
-<a name="a-sample-basic-workflow">
-## A sample basic workflow ##
-</a>
+A sample basic workflow
+-----------------------
 
 The following program listing, compilation, and execution workflow exemplify
 the use of an OCA compiler (e.g., gfortran 5.1.0 or later) in a Linux bash shell
-with the "bin" directory of the chosen installation path in the user's PATH
+with the `bin` directory of the chosen installation path in the user's PATH
 environment variable:
 
-      $ cat tally.f90
+```
+$ cat tally.f90
       program main
         use iso_c_binding, only : c_int
         use iso_fortran_env, only : error_unit
@@ -72,35 +74,42 @@ environment variable:
         sync all
         if (this_image()==1) print *,"Test passed"
       end program
-      $ caf tally.f90 -o tally
-      $ cafrun -np 4 ./tally
+$ caf tally.f90 -o tally
+$ cafrun -np 4 ./tally
         Test passed
+```
 
 where "4" is the number of images to be launched at program start-up.
 
-<a name="an-advanced-workflow">
-## An advanced workflow </a> ##
+An advanced workflow
+--------------------
 
 To extend the capabilities of a non-OCA CAF compiler (e.g., the Intel or Cray compilers),
-access the types and procedures of the [opencoarrays module] by use assocication.  We
+access the types and procedures of the [opencoarrays module] by use association.  We
 recommend using a `use` statement with an `only` clause to reduce the likelihood of a
-name clash with the compiler's native CAf support.  For eample, innsert the following
+name clash with the compiler's native CAf support.  For example, insert the following
 at line 2 of `tally.f90` above:
 
-     use opencoarrays, only : co_sum
+```fortran
+use opencoarrays, only : co_sum
+```
 
 To extend the capabilities of a non-CAF compiler (e.g., GCC 4.9), use an unqualified
-`use` statement with no `only` clause.  The latter practrice reduces the likelihood of
+`use` statement with no `only` clause.  The latter practice reduces the likelihood of
 name clashes with the compiler's or programs existing capabilities.
 
-If the "caf" compiler wrapper cannot process the source code in question, invoke
+If the `caf` compiler wrapper cannot process the source code in question, invoke
 the underlying communication library directly:
 
-    mpif90 -fcoarray=lib -L/opt/opencoarrays/ tally.f90 \ -lcaf_mpi -o htally-I<OpenCoarrays-install-path>/mod
+```
+mpif90 -fcoarray=lib -L/opt/opencoarrays/ tally.f90 \ -lcaf_mpi -o htally-I<OpenCoarrays-install-path>/mod
+```
 
 and also run the program with the lower-level communication library:
 
-    mpirun -np <number-of-images> ./tally
+```
+mpirun -np <number-of-images> ./tally
+```
 
 [Hyperlinks]:#
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -7,6 +7,11 @@
 Getting Started
 ===============
 
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/GETTING_STARTED.pdf)
+
+Download this file as a PDF document
+[here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/GETTING_STARTED.pdf).
+
 * [The caf compiler wrapper]
 * [A sample basic workflow]
 * [An advanced workflow]
@@ -124,3 +129,4 @@ mpirun -np <number-of-images> ./tally
 [TS 18508]: http://isotc.iso.org/livelink/livelink?func=ll&objId=17181227&objAction=Open
 [The caf compiler wrapper]: #the-caf-compiler-wrapper
 [The cafrun program launcher]: #the-cafrun-program-launcher
+[pdf img]: https://img.shields.io/badge/PDF-GETTING_STARTED.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,11 @@
+<a name="top"> </a>
+
 [This document is formatted with GitHub-Flavored Markdown.               ]:#
 [For better viewing, including hyperlinks, read it online at             ]:#
 [https://github.com/sourceryinstitute/opencoarrays/blob/master/INSTALL.md]:#
 
-# [Installing OpenCoarrays](#installing-opencoarrays)
+Installing OpenCoarrays
+=======================
 
  *  [End-User Installation]
      * [Installation Script]
@@ -15,68 +18,68 @@
      *  [Make]
  *  [Obtaining GCC]
 
-<a name="end-user-installation">
-## End-User Installation ##
-</a>
+End-User Installation
+---------------------
 
-<a name="installation-script">
 ### Installation Script###
-</a>
 
 As of release 1.2.0, users might consider installing by downloading and uncompressing
 a file from our [Releases] page and running the installation script in the top-level
 source directory:
 
-    tar xvzf opencoarrays-x.y.z.tar.gz
-    cd opencoarrays
-    ./install.sh
+```
+tar xvzf opencoarrays-x.y.z.tar.gz
+cd opencoarrays
+./install.sh
+```
 
 Before installing OpenCoarrays, the above bash script will attempt to detect the presence
-of the default prequisite packages: [GCC], [MPICH] , and [CMake] packges.  If any of the
-aforementioned packages appears to be absent from the user's PATH environment variable,
+of the default prequisite packages: [GCC], [MPICH] , and [CMake].  If any of the
+aforementioned packages appear to be absent from the user's PATH environment variable,
 the [install.sh] script will attempt to download, build, and install any missing packages
 after asking permission to do so.  The script has been tested on Linux and OS X.  Please
 submit any related problems or questions to our [Issues] page.
 
 A complete installation should result in the creation of the following directories
-inside the installation path (.e.g, inside "build" in the above example):
+inside the installation path (.e.g, inside `build` in the above example):
 
-* bin: contains the compiler wrapper (caf), program launcher (cafun), and prerequisites builder (build)
-* mod: contains the "opencoarrays.mod" module file for use with non-OpenCoarrays-aware compilers
-* lib: contains the "libcaf_mpi.a" static library to which codes link for CAF support
+* `bin`: contains the compiler wrapper (`caf`), program launcher (`cafun`), and prerequisites builder (`build`)
+* `mod`: contains the `opencoarrays.mod` module file for use with non-OpenCoarrays-aware compilers
+* `lib`: contains the `libcaf_mpi.a` static library to which codes link for CAF support
 
 The remainder of this document explains other options that many end users will find
 simplest to obtain OpenCoarrays on OS X, Windows, or Linux without building OpenCoarrays
 from its source code.
 
-<a name="os-x">
-### OS X###
-</a>
+### OS X ###
 
 OS X users might find it easiest to install OpenCoarrays using the [MacPorts]
-package management system.  After installing MacPorts, type the following:
+package management system.  After installing [MacPorts], type the following:
 
-    sudo port selfupdate
-    sudo port upgrade outdated
-    sudo port install opencoarrays
+```
+sudo port selfupdate
+sudo port upgrade outdated
+sudo port install opencoarrays
+```
 
-where the "sudo" command requires Administrator privileges and where the first
-two steps above are required only if the MacPorts ports were last updated prior
-to 30 September 2015, when the OpenCoarrays port was incorporated into MacPorts.
+where the `sudo` command requires administrator privileges and where the first
+two steps above are required only if the [MacPorts] ports were last updated prior
+to 30 September 2015, when the OpenCoarrays port was incorporated into [MacPorts].
 Repeating the first two steps above will also update OpenCoarrays to the latest
 release.
 
-Please also install the mpstats port as follows:
+Please also install the `mpstats` port as follows:
 
-    sudo port install mpstats
+```
+sudo port install mpstats
+```
 
 which supports future OpenCoarrays development by providing download data the
 OpenCoarrays team can use in proposals for research grants and development
 contracts.
 
-<a name="windows">
 ### Windows ###
-</a>
+
 Windows users will find it easiest to download the Lubuntu Linux virtual
 machine from the [Sourcery Institute Store].  The virtual machine boots inside
 the open-source [VirtualBox] virtualization package.  In addition to containing
@@ -88,9 +91,7 @@ for a partial list of the included packages.
 Alternatively, if you desire to use OpenCoarrays under Cygwin, please submit a
 feature request via our [Issues] page.
 
-<a name="linux">
 ### Linux ###
-</a>
 
 The [Arch Linux] distribution provides an [aur package] for installing OpenCoarrays.
 Users of other Linux distributions who prefer not to build OpenCoarrays from source might
@@ -100,13 +101,10 @@ for the relevant Linux distribution.  Alternatively, if you desire to install us
 Linux package management software such as [yum] or [apt-get], please submit a feature
 request via our [Issues] page.
 
-<a name="buildingfromsource">
-## Building from source ##
-</a>
+Building from source
+--------------------
 
-<a name="prerequisits">
 ### Prerequisites: ###
-</a>
 
 For broad coverage of CAF features, ease of installation, and ease of use, first
 install the following:
@@ -122,15 +120,15 @@ The [install_prerequisites] directory contains experimental [buildgcc], [buildmp
 [GCC]  C, C++, and Fortran compilers; the [CMake] build sytem; and the [MPICH] communication
 library.  (Because newer parts of the GNU Fortran compiler gfortran are written in C++,
 installing the GNU Fortran compiler from source requires also installing the GNU C++ compiler
-g++.)  The CMake scripts that build OpenCoarrays also copy [buildgcc], [buildmpich], and
-[buildcmake] into the "bin" directory of the OpenCoarrays installation for later use.
+`g++`.)  The CMake scripts that build OpenCoarrays also copy [buildgcc], [buildmpich], and
+[buildcmake] into the `bin` directory of the OpenCoarrays installation for later use.
 
 We have tested the build scripts  on OS X and Linux. Please submit suggestions for improving
 the scripts to our [Issues] page or preferably suggeste edits by forking a copy of the
 [OpenCoarrays] repository, making the suggested edits, and submitting a pull request.
 
 If installing the above prerequisites is infeasible, then a limited coverage of CAF
-features is available via the OpenCoarrays "caf" compiler wrapper and the
+features is available via the OpenCoarrays `caf` compiler wrapper and the
 [opencoarrays] module, for which the installation prerequisites are the following:
 
 * A Fortran compiler that supports the C-interoperability features of Fortran 2003,
@@ -139,28 +137,28 @@ features is available via the OpenCoarrays "caf" compiler wrapper and the
   Fortran and C compilers (preferably the [MPICH] or [MVAPICH] implementations for
   robustness and high performance)
 
-<a name="cmake">
 ### CMake ###
-</a>
-------------------------------------------
+
 [CMake] is the preferred build system.   CMake is a cross-platform Makefile generator that
 includes with the testing tool CTest.  To avoid cluttering or clobbering the source tree,
 our CMake setup requires that your build directory be any directory other than the top-level
 OpenCoarrays source directory.  In a bash shell, the following steps should build
 OpenCoarrays, install OpenCoarrays, build the tests, run the tests, and report the test results:
 
-    tar xvzf opencoarrays.tar.gz
-    cd opencoarrays
-    mkdir opencoarrays-build
-    cd opencoarrays-build
-    CC=mpicc FC=mpif90 cmake .. -DCMAKE_INSTALL_PREFIX=${PWD}
-    make
-    make install
-    ctest
+```
+tar xvzf opencoarrays.tar.gz
+cd opencoarrays
+mkdir opencoarrays-build
+cd opencoarrays-build
+CC=mpicc FC=mpif90 cmake .. -DCMAKE_INSTALL_PREFIX=${PWD}
+make
+ctest
+make install
+```
 
 where the the first part of the cmake line sets the CC and FC environment variables
 and the final part of the same line defines the installation path as the present
-working directory ("opencoarrays-build").  Please report any test failures via the
+working directory (`opencoarrays-build`).  Please report any test failures via the
 OpenCoarrays [Issues] page.
 
 Advanced options (most users should not use these):
@@ -175,35 +173,36 @@ The first two flags above are not portable and the third enables code that is in
 of release 1.0.0.  The fourth is set automatically by the CMake scripts based on the compiler
 identity and version.
 
-<a name="make">
 ### Make ###
-</a>
 
 Unlike the Makefiles that CMake generates automatically for the chosen platform, static
 Makefiles require a great deal more maintenance and are less portable.  Also, the static
 Makefiles provided with OpenCoarrays lack several important capabilities.  In particular,
 they will not build the tests;  they will not build any of the infrastructure for compiling
 CAF source with non-OpenCoarrays-aware compilers (that infrastructure includes the
-[opencoarrays] module, the "caf" compiler wrapper, and the "cafrun" program launcher);
-nor do the static Makefiles provide a "make install" option so you will need to manually
+[opencoarrays] module, the `caf` compiler wrapper, and the `cafrun` program launcher);
+nor do the static Makefiles provide a `make install` option so you will need to manually
 move the desired library from the corresponding source directory to your intended installation
 location as shown below.
 
 If CMake is unavailable, build and install with Make using steps such as the following:
 
-    tar xvzf opencoarrays.tar.gz
-    cd opencoarray/src
-    make
-    mv mpi/libcaf_mpi.a <installation-path>
+```
+tar xvzf opencoarrays.tar.gz
+cd opencoarray/src
+make
+mv mpi/libcaf_mpi.a <installation-path>
+```
 
-For the above steps to succeeed, you might need to edit the [make.inc] file to match your
-system settings.  For example, you might need to remove the "-Werror" option from the
+For the above steps to succeed, you might need to edit the [make.inc] file to match your
+system settings.  For example, you might need to remove the `-Werror` option from the
 compiler flags or name a different compiler.  In order to activate efficient strided-array
-transfer support, uncomment the -DSTRIDED flag inside the [make.inc] file.
+transfer support, uncomment the `-DSTRIDED` flag inside the [make.inc] file.
 
-## <a name="obtaingcc">Obtaining GCC, MPICH, and CMake</a> ##
+Obtaining GCC, MPICH, and CMake
+-------------------------------
 
-[GFortran Binaries] 5 binary builds are available at [https://gcc.gnu.org/wiki/GFortranBinaries].  Also,
+[GFortran Binaries] 5 binary builds are available at <https://gcc.gnu.org/wiki/GFortranBinaries>.  Also,
 the Lubuntu Linux virtual machine available for download in the [Sourcery Store] includes
 builds of GCC 4.9, 5.2, and 6.0.
 
@@ -212,13 +211,17 @@ you might first try the running the provided [install.sh] script as described ab
 the [Installation Script] section.  Or try building each prerequisite from source as
 follows:
 
-    cd install_prerequisites
-    CC=gcc FC=gfortran CXX=g++ ./build flex
-    ./build gcc
-    CC=gcc FC=gfortran CXX=g++ ./build mpich
-    ./build cmake
+```
+cd install_prerequisites
+CC=gcc FC=gfortran CXX=g++ ./build flex
+./build gcc
+CC=gcc FC=gfortran CXX=g++ ./build mpich
+./build cmake
+```
 
 where the second line builds the flex package that is required for building gcc from source.
+
+[Links]: #
 
 [End-User Installation]: #end-user-installation
 [Installation Script]: #installation-script
@@ -234,7 +237,7 @@ where the second line builds the flex package that is required for building gcc 
 [Obtaining GCC]: #obtaining-gcc
 [Sourcery Store]: http://www.sourceryinstitute.org/store
 [Sourcery Institute Store]: http://www.sourceryinstitute.org/store
-[Virtualbox]: http://www.virtualbox.org
+[VirtualBox]: http://www.virtualbox.org
 [download and installation instructions]: http://www.sourceryinstitute.org/uploads/4/9/9/6/49967347/overview.pdf
 [yum]: http://yum.baseurl.org
 [apt-get]: https://en.wikipedia.org/wiki/Advanced_Packaging_Tool
@@ -247,7 +250,7 @@ where the second line builds the flex package that is required for building gcc 
 [buildcmake]: ./install_prerequisites/buildcmake
 [MPICH]: http://www.mpich.org
 [MVAPICH]:http://mvapich.cse.ohio-state.edu
-[Macports]: http://www.macports.org
+[MacPorts]: http://www.macports.org
 [GCC]: http://gcc.gnu.org
 [TS18508 Additional Parallel Features in Fortran]: http://isotc.iso.org/livelink/livelink?func=ll&objId=17181227&objAction=Open
 [GFortran Binaries]:  https://gcc.gnu.org/wiki/GFortranBinaries#FromSource

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,11 @@
 Installing OpenCoarrays
 =======================
 
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/INSTALL.pdf)
+
+Download this file as a PDF document
+[here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/INSTALL.pdf).
+
  *  [End-User Installation]
      * [Installation Script]
      * [OS X]
@@ -258,3 +263,4 @@ where the second line builds the flex package that is required for building gcc 
 [Arch Linux]: https://www.archlinux.org
 [aur package]: https://aur.archlinux.org/packages/opencoarrays/
 [Releases]: https://github.com/sourceryinstitute/opencoarrays/releases
+[pdf img]: https://img.shields.io/badge/PDF-INSTALL.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2015, Sourcery Institute
+Copyright (c) 2016, Sourcery Institute
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ OpenCoarrays
 ============
 
 [![CI Build Status][build img]](https://travis-ci.org/sourceryinstitute/opencoarrays)
-[![GitHub release][release img]](https://github.com/sourceryinstitute/opencoarrays/releases/latest)
-[![GitHub license][license img]](COPYRIGHT-BSD3)
+[![GitHub license][license img]](./COPYRIGHT-BSD3)
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/README.pdf)
+<!-- [![GitHub release][release img]](https://github.com/sourceryinstitute/opencoarrays/releases/latest) -->
 <!-- [![Release Downloads][download img]](https://github.com/sourceryinstitute/opencoarrays/releases) -->
+
+Download this file as a PDF document [here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/README.pdf).
 
 * [Overview](#overview)
 * [Downloads](#downloads)
@@ -35,7 +38,7 @@ OpenCoarrays enables CAF application developers to express parallel algorithms w
 
 Downloads
 ---------
-[![Release Downloads][download img]](https://github.com/sourceryinstitute/opencoarrays/releases/latest)
+<!--[![Release Downloads][download img]](https://github.com/sourceryinstitute/opencoarrays/releases/latest)-->
 
 Please see our [Releases] page.
 
@@ -125,8 +128,9 @@ We gratefully acknowledge support from the following institutions:
 [Issues]: https://github.com/sourceryinstitute/opencoarrays/issues
 [Releases]: https://github.com/sourceryinstitute/opencoarrays/releases
 
-[build img]: https://img.shields.io/travis-ci/sourceryinstitute/opencoarrays/master.svg?style=flat-square "Travis-CI badge image source"
-[CI Master Branch]: https://travis-ci.org/sourceryinstitute/opencoarrays?branch=master "Travis-CI builds"
+[build img]: https://img.shields.io/travis-ci/sourceryinstitute/opencoarrays/master.svg?style=flat-square "View Travis-CI builds"
+[CI Master Branch]: https://travis-ci.org/sourceryinstitute/opencoarrays?branch=master "View Travis-CI builds"
 [download img]: https://img.shields.io/github/downloads/sourceryinstitute/opencoarrays/total.svg?style=flat-square "Download count image source"
-[license img]: https://img.shields.io/github/license/sourceryinstitute/opencoarrays.svg?style=flat-square "BSD-3 License badge"
-[release img]: https://img.shields.io/github/release/sourceryinstitute/opencoarrays.svg?style=flat-square "Latest release badge"
+[license img]: https://img.shields.io/badge/License-BSD--3-blue.svg?style=flat-square "View BSD-3 License"
+[release img]: https://img.shields.io/github/release/sourceryinstitute/opencoarrays.svg?style=flat-square "View latest release"
+[pdf img]: https://img.shields.io/badge/PDF-README.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/README.md
+++ b/README.md
@@ -1,70 +1,82 @@
+<a name="top"> </a>
+
 [This document is formatted with GitHub-Flavored Markdown.              ]:#
 [For better viewing, including hyperlinks, read it online at            ]:#
 [https://github.com/sourceryinstitute/opencoarrays/blob/master/README.md]:#
 
-# OpenCoarrays #
+OpenCoarrays
+============
 
 [![CI Build Status][build img]](https://travis-ci.org/sourceryinstitute/opencoarrays)
 [![GitHub release][release img]](https://github.com/sourceryinstitute/opencoarrays/releases/latest)
 [![GitHub license][license img]](COPYRIGHT-BSD3)
 <!-- [![Release Downloads][download img]](https://github.com/sourceryinstitute/opencoarrays/releases) -->
 
-* [Overview]
-* [Downloads]
-* [Compatibility]
-* [Prerequisites]
-* [Installation]
-* [Contributing]
-* [Acknowledgements]
+* [Overview](#overview)
+* [Downloads](#downloads)
+* [Compatibility](#compatibility)
+* [Prerequisites](#prerequisites)
+* [Installation](#installation)
+* [Getting Started](#getting-started)
+* [Contributing](#contributing)
+* [Status](#status)
+* [Support](#support)
+* [Acknowledgements](#acknowledgements)
 
-## <a name="overview">Overview</a> ##
+Overview
+--------
 [OpenCoarrays] is an open-source software project that supports the coarray Fortran (CAF) parallel programming features of the Fortran 2008 standard and several features proposed for Fortran 2015 in the draft Technical Specification [TS 18508] _Additional Parallel Features in Fortran_.
 
-OpenCoarrays provides a compiler wrapper (named "caf"), a runtime library (named "libcaf_mpi.a" by default), and an executable file launcher (named "cafrun").  With OpenCoarrays-aware compilers, the compiler wrapper passes the provided source code to the chosen compiler ("mpif90" by default).  For non-OpenCoarrays-aware compilers, the wrapper transforms CAF syntax into OpenCoarrys procedure calls before invoking the chosen compiler on the transformed code.  The runtime library supports compiler communication and synchronization requests by invoking a lower-level communication library -- the Message Passing Interface ([MPI]) by default.  The launcher passes execution to the chosen communication library's parallel program launcher ("mpirun" by default).
+OpenCoarrays provides a compiler wrapper (named `caf`), a runtime library (named `libcaf_mpi.a` by default), and an executable file launcher (named `cafrun`).  With OpenCoarrays-aware compilers, the compiler wrapper passes the provided source code to the chosen compiler (`mpif90` by default).  For non-OpenCoarrays-aware compilers, the wrapper transforms CAF syntax into OpenCoarrys procedure calls before invoking the chosen compiler on the transformed code.  The runtime library supports compiler communication and synchronization requests by invoking a lower-level communication library--the Message Passing Interface ([MPI]) by default.  The launcher passes execution to the chosen communication library's parallel program launcher (`mpirun` by default).
 
 OpenCoarrays defines an application binary interface ([ABI]) that translates high-level communication and synchronization requests into low-level calls to a user-specified communication library.  This design decision liberates compiler teams from hardwiring communication-library choice into their compilers and it frees Fortran programmers to express parallel algorithms once and reuse identical CAF source with whichever communication library is most efficient for a given hardware platform.  The communication substrate for OpenCoarrays built with the preferred build system, CMake, is the Message Passing Interface ([MPI]).
 
 OpenCoarrays enables CAF application developers to express parallel algorithms without hardwiring a particular version of a particular communication library or library version into their codes.  Such abstraction makes application code less sensitive to the evolution of the underlying communication libraries and hardware platforms.
 
-<a name="downloads">
-## Downloads</a> ##
+Downloads
+---------
+[![Release Downloads][download img]](https://github.com/sourceryinstitute/opencoarrays/releases/latest)
+
 Please see our [Releases] page.
 
-## <a name="compatibility">Compatibility</a> ##
-The GNU Compiler Collection ([GCC]) Fortran front end ([gfortran]) is OpenCoarrays-aware for release versions 5.1.0 and higher.  Users of other compilers, including earlier versions of gfortran, can access a limited subset of CAF features via the provided [opencoarrays module].  After installation, please execute the "caf" script (which is installed in the "bin" directory of the installation path) with no arguments to see a list of the corresponding limitations.  Please also notify the corresponding compiler vendor and the OpenCoarrays team that you would like for a future version of the compiler to be OpenCoarrays-aware.
+Compatibility
+-------------
+The GNU Compiler Collection ([GCC]) Fortran front end ([gfortran]) is OpenCoarrays-aware for release versions 5.1.0 and higher.  Users of other compilers, including earlier versions of gfortran, can access a limited subset of CAF features via the provided [opencoarrays module].  After installation, please execute the `caf` script (which is installed in the `bin` directory of the installation path) with no arguments to see a list of the corresponding limitations.  Please also notify the corresponding compiler vendor and the OpenCoarrays team that you would like for a future version of the compiler to be OpenCoarrays-aware.
 
-## <a name="prerequisites">Prerequisites</a> ##
+Prerequisites
+-------------
 We expect our LIBCAF_MPI library to be the default OpenCoarrays library.  LIBCAF_MPI is the most straightforward to install and use, the most robust in terms of its internal complexity, and the most frequently updated and maintained.  Building LIBCAF_MPI requires prior installation of an MPI implementation.  We recommend [MPICH] generally or, if available, [MVAPICH] for better performance. [OpenMPI] is another option.
 
 We offer an unsupported LIBCAF_GASNet alternative.  We intend for LIBCAF_GASNet to be an "expert" alternative capable of outperforming MPI for some applications on some platforms.  LIBCAF_GASNet requires greater care to configure and use and building LIBCAF_GASNet requires prior installation of [GASNet].
 
-<a name="installation">
-## Installation</a> ##
+Installation
+------------
 
 Please see the [INSTALL.md] file.
 
-<a name="installation">
-## Getting Started</a> ##
+Getting Started
+---------------
 
 To start using OpenCoarrays, please see the [GETTING_STARTED.md] file.
 
-<a name="contributing">
-## Contributing</a> ##
+Contributing
+------------
 
 Please see the [CONTRIBUTING.md] file.
 
-<a name="status">
-## Status</a> ##
+Status
+------
 
 Please see the [STATUS.md] file.
 
-## <a name="support">Support</a> ##
+Support
+-------
 
-* Please submit bug reports and feature requests via our [Issues]).
+* Please submit bug reports and feature requests via our [Issues] page.
 * Please submit questions regarding installation and use via our [Google Group] by signing into [Google Groups] or [subscribing] and sending email to [opencoarrays@googlegroups.com].
-* We offer an additional [menu of services] on a contract basis.
 
-## <a name="acknowledgements">Acknowledgements</a> ##
+Acknowledgements
+----------------
 We gratefully acknowledge support from the following institutions:
 
 * [National Center for Atmospheric Research] for access to the Yellowstone/Caldera supercomputers and for logistics support during the initial development of OpenCoarrays.
@@ -101,7 +113,6 @@ We gratefully acknowledge support from the following institutions:
 [National Center for Atmospheric Research]: http://ncar.ucar.edu
 [INSTALL.md]: ./INSTALL.md
 [GASNet]: http://gasnet.lbl.gov
-[menu of services]: http://opencoarrays.org/services
 [CONTRIBUTING.md]: ./CONTRIBUTING.md
 [STATUS.md]: ./STATUS.md
 [GETTING_STARTED.md]: ./GETTING_STARTED.md
@@ -109,9 +120,9 @@ We gratefully acknowledge support from the following institutions:
 [Google Group]: https://groups.google.com/forum/#!forum/opencoarrays
 [subscribing]: https://groups.google.com/forum/#!forum/opencoarrays/join
 [opencoarrays@googlegroups.com]: mailto:opencoarrays@googlegroups.com
-[Google Summer of Code]: https://www.google-melange.com
+[Google Summer of Code]: https://www.google-melange.com/gsoc/org2/google/gsoc2014/gcc
 [OpenCoarrays Google Group]: https://groups.google.com/forum/#!forum/opencoarrays)
-[Issues]: https://github.com/sourceryinstitute/opencoarrays/issue
+[Issues]: https://github.com/sourceryinstitute/opencoarrays/issues
 [Releases]: https://github.com/sourceryinstitute/opencoarrays/releases
 
 [build img]: https://img.shields.io/travis-ci/sourceryinstitute/opencoarrays/master.svg?style=flat-square "Travis-CI badge image source"

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,6 +7,11 @@
 OpenCoarrays Status
 ===================
 
+[![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/STATUS.pdf)
+
+Download this file as a PDF document
+[here](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/STATUS.pdf).
+
  *  [Feature Coverage](#feature-coverage)
  *  [Compiler Status](#compiler-status)
      * [OpenCoarrays-Aware (OCA) Coarray Fortran (CAF) Compilers]
@@ -198,3 +203,4 @@ To-Do List
 [OpenCoarrays Google Group]: https://groups.google.com/forum/#!forum/opencoarrays
 [Sourcery Store]: http://www.sourceryinstitute.org/store
 [Issues]: https://github.com/sourceryinstitute/opencoarrays/issues
+[pdf img]: https://img.shields.io/badge/PDF-STATUS.md-6C2DC7.svg?style=flat-square "Download as PDF"

--- a/STATUS.md
+++ b/STATUS.md
@@ -156,13 +156,13 @@ Known Issues
 To-Do List
 ----------
 
-* Additional tests and documentation.
-* Improvement of error handling and diagnostics, including but not
-  limited to filling the `ERRMSG=` variable in case of errors.
-* Providing a diagnostic mode with run-time consistency checks.
-* Better integration with the test cases of GCC.  For more information,
-  see the GCC source code files in `gcc/testsuite/gfortran.dg/`,
-  in particular, the `dg-do run` tests in `coarray*f90` and `coarray/`).
+* [ ] Additional tests and documentation.
+* [ ] Improvement of error handling and diagnostics, including but not
+      limited to filling the `ERRMSG=` variable in case of errors.
+* [ ] Providing a diagnostic mode with run-time consistency checks.
+* [ ] Better integration with the test cases of GCC.  For more information,
+      see the GCC source code files in `gcc/testsuite/gfortran.dg/`,
+      in particular, the `dg-do run` tests in `coarray*f90` and `coarray/`).
 
 
 [Hyperlinks]:#

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,32 +1,36 @@
+<a name="top"> </a>
+
 [This document is formatted with GitHub-Flavored Markdown.              ]:#
 [For better viewing, including hyperlinks, read it online at            ]:#
 [https://github.com/sourceryinstitute/opencoarrays/blob/master/STATUS.md]:#
 
-# [OpenCoarrays Status](#coarray-fortran-support-status) #
- *  [Feature Coverage]
- *  [Compiler Status]
+OpenCoarrays Status
+===================
+
+ *  [Feature Coverage](#feature-coverage)
+ *  [Compiler Status](#compiler-status)
      * [OpenCoarrays-Aware (OCA) Coarray Fortran (CAF) Compilers]
      * [Non-OCA CAF Compilers]
      * [Non-CAF Compilers]
- *  [Library Status]
+ *  [Library Status](#libary-status)
      *  [libcaf_mpi]
      *  [libcaf_x]
      *  [libcaf_gasnet]
      *  [libcaf_armci]
      *  [libcaf_single]
- *  [Known Issues]
-     * [Library Issues]
-     * [Compiler Issues]
+ *  [Known Issues](#known-issues)
+     * [Library Issues](#library-issues)
+     * [Compiler Issues](#compiler-issues)
          * [GNU (gfortran)]
          * [Cray (ftn)]
          * [Intel (ifort)]
          * [Numerical Algorithms Group (nagfor)]
          * [Portland Group (pgfortran)]
          * [IBM (xlf)]
- *  [To-Do List]
+ *  [To-Do List](#to-do-list)
 
-<a name="feature-coverage">
-## Feature coverage</a> ##
+Feature Coverage
+----------------
 
  * Except as noted under [Known Issues], [libcaf_mpi] supports the following features as described
    in the Fortran 2008 standard:
@@ -40,40 +44,40 @@
    [TS 18508] _Additional Parallel Features in Fortra_ subroutines for a limited
    set of intrinsic types and kinds.  Adding additional types and kinds is
    straightforward.  Please submit a request via the [Issues] page or consider
-   adding the requisite code by forking the OpenCoarrays repository and submitting
+   adding the requisite code by [forking the OpenCoarrays repository] and submitting
    [pull request via GitHub]. Also see [CONTRIBUTING.md] for more information.
 
-<a name="compiler-status">
-## Compiler Status</a> ##
+Compiler Status
+---------------
 
 The OpenCoarrays CMake build and test scripts detect the compiler identity, version, and operating system (OS).  The scripts use this information to build and test the approproiate functionality for the compiler and OS. Each current compilers' status falls into one of three categories:
 
 <a name="oca-caf-compilers">
  * **OpenCoarrays-Aware (OCA) Coarray Fortran (CAF) Compilers**</a>
      * _Definition:_ The compiler translates CAF statements into OpenCoarrays application binary interface ([ABI]) calls.
-     * _Example_: GNU Fortran 5.1 or later (see [https://gcc.gnu.org/wiki/Coarray] for the compiler's CAF status..
+     * _Example_: GNU Fortran 5.1 or later (see <https://gcc.gnu.org/wiki/Coarray> for the compiler's CAF status..)
      * _Use case_: compile most Fortran 2008 coarray programs and some programs that use proposed Fortran 2015 features.
 <a name="non-oca-caf-compilers">
  * **Non-OCA CAF Compilers**</a>
-     * _Definition:_ The compiler supports CAF but does not generate calls to the OpenCoarrays ABI.
+     * _Definition:_ The compiler supports CAF but does not generate calls to the OpenCoarrays [ABI].
      * _Examples_: Cray compiler (except on CS Series clusters), Intel compiler (except on OS X).
-     * _Use case_: extend the compiler's native CAF using the [opencoarrys module] types and procedures.
+     * _Use case_: extend the compiler's native CAF using the [opencoarrays module] types and procedures.
 <a name="non-caf-compilers">
  * **Non-CAF Compilers**</a>
      * _Definition_: The compiler provides no direct support for CAF, but the user can access a subset of CAF features via use association with the [opencoarrays module], e.g., `use opencoarrays, only : co_sum`.
      * _Examples_: GNU Fortran 4.9 or any compiler not mentioned above.
-     * _Use case_: Use the OpenCoarrays "caf" compiler wrapper to compile those CAF  programs for which the proposed Fortran 2015 collective subroutines cover all of the application's communication requirements.
+     * _Use case_: Use the OpenCoarrays `caf` compiler wrapper to compile those CAF  programs for which the proposed Fortran 2015 collective subroutines cover all of the application's communication requirements.
 
 We have encountered several research applications that match the latter use case.  If you encounter difficulties, please submit a bug report or feature request via the [Issues] page. Also submit a feature request to the relevant compiler technical support.
 
-The OpenCoarrays team offers contract development and support for making compilers OpenCoarrays-aware.  If this is of interest, please inform the compiler's technical support as well as the OpenCoarrays team.   To contribute code, including documentation and tests, see the [CONTRIBUTIONS] file.  To contribute funding, including funding in support of feature reqeusts, see the [Sourcery Store].
+The OpenCoarrays team offers contract development and support for making compilers OpenCoarrays-aware.  If this is of interest, please inform the compiler's technical support as well as the OpenCoarrays team.   To contribute code, including documentation and tests, see the [CONTRIBUTING.md] file.  To contribute funding, including funding in support of feature reqeusts, see the [Sourcery Store].
 
-<a name="library-status">
-## Library Status</a> ##
+Library Status
+--------------
 
 <a name="libcaf-mpi">
 * **libcaf_mpi**</a> (Default CMake build): Production transport layer that uses
-  the Message Passing Interface (MPI) 3.0 one-sided communication, which
+  the Message Passing Interface ([MPI]) 3.0 one-sided communication, which
   exploits a hardware platform's native support for Remote Direct Memory
   Access (RDMA) if available.
 <a name="libcaf-x">
@@ -86,8 +90,8 @@ The OpenCoarrays team offers contract development and support for making compile
   graphics processing units (GPUs) and heterogeneous CPU/GPU platforms.
 <a name="libcaf-gasnet">
 * **libcaf_gasnet**</a> (Advanced Make build): Experimental transport layer that
-  is currently out-of-date but might exhibit higher performance than MPI on
-  platforms for which GASNet provides a tuned conduit.  Contact the
+  is currently out-of-date but might exhibit higher performance than [MPI] on
+  platforms for which [GASNet] provides a tuned conduit.  Contact the
   [OpenCoarrays Google Group] for further information.
 <a name="libcaf-armci">
 * **libcaf_armci**</a> (Unsupported): developed for research purposes and evaluation.
@@ -96,15 +100,15 @@ The OpenCoarrays team offers contract development and support for making compile
   is included in GNU Fortran to facilitate compiling single-image (sequential)
   executables from CAF programs in the absence of a parallel communication library.
 
-<a name="known-issues">
-## Known Issues</a> ##
+Known Issues
+------------
 
-<a name="library-issues">
-### Library Issues </a> ###
-* The [opencoarrays module] and "caf" compiler wrapper do not support the square-bracket
+### Library Issues ###
+
+* The [opencoarrays module] and `caf` compiler wrapper do not support the square-bracket
   syntax required for point-to-point communication.  This limitation only impacts
   [non-CAF compilers]. For a list of other limitations with non-CAF compilers, execute
-  the "caf' bash script with no arguments.  The "caf" script is installed in the "bin"
+  the `caf` bash script with no arguments.  The `caf` script is installed in the `bin`
   subdirectory of the installation path.
 * Efficient strided array transfer works only for intrinsic types.
 * Efficient strided array transfer is not supported for remote-to-remote transfers.
@@ -115,8 +119,7 @@ The OpenCoarrays team offers contract development and support for making compile
      * For array assignments, some issues with numeric type conversion exist.
 
 
-<a name="compiler-issues">
-### Compiler Issues </a> ###
+### Compiler Issues ###
 
 <a name="compiler-issues-gnu">
 * **GNU** (gfortran)</a>
@@ -131,7 +134,7 @@ The OpenCoarrays team offers contract development and support for making compile
      * `co_reduce` only supports arguments of intrinsic type.
      * No support for type finalization or allocatable components of derived-type coarrays
        passed to the collective subroutines (e.g., `co_sum`, `co_reduce`, etc.).
-	 * Optimization levels other than -O0 introduce correctness errors
+	 * Optimization levels other than `-O0` introduce correctness errors
 	   in the compiled binaries. A patch has been submitted by @afanfa
 	   to the GFortran team. See #28 for some more context.
 <a name="compiler-issues-intel">
@@ -150,47 +153,48 @@ The OpenCoarrays team offers contract development and support for making compile
 * **IBM** (xlf)</a>
      * Supported via the [opencoarrays module] only.
 
-<a name="to-do-list">
-## To-Do List</a> ##
+To-Do List
+----------
 
 * Additional tests and documentation.
 * Improvement of error handling and diagnostics, including but not
-  limited to filling the ERRMSG= variable in case of errors.
+  limited to filling the `ERRMSG=` variable in case of errors.
 * Providing a diagnostic mode with run-time consistency checks.
 * Better integration with the test cases of GCC.  For more information,
-  see the GCC source code files in gcc/testsuite/gfortran.dg/,
-  in particular, the "dg-do run" tests in coarray*f90 and coarray/).
+  see the GCC source code files in `gcc/testsuite/gfortran.dg/`,
+  in particular, the `dg-do run` tests in `coarray*f90` and `coarray/`).
 
 
 [Hyperlinks]:#
-
-[Compiler Status]: #compiler-status
+   [OpenMP]: http://openmp.org
+   [CUDA]: http://www.nvidia.com/object/cuda_home_new.html
+   [Pthreads]: https://computing.llnl.gov/tutorials/pthreads/
+   [MPI]: http://www.mpi-forum.org
+   [OpenSHMEM]: http://openshmem.org
+   [GASNet]: https://gasnet.lbl.gov
+   [CONTRIBUTING.md]: ./CONTRIBUTING.md
    [OpenCoarrays-Aware (OCA) Coarray Fortran (CAF) Compilers]: #oca-caf-compilers
+   [Known Issues]: #known-issues
    [Non-OCA CAF Compilers]: #non-oca-caf-compilers
    [Non-CAF Compilers]: #non-caf-compilers
-[Library Status]: #library-status
    [libcaf_mpi]: #libcaf-mpi
    [libcaf_x]: #libcaf-x
    [libcaf_gasnet]:  #libcaf-gasnet
    [libcaf_single]: #libcaf-single
    [libcaf_armci]: #libcaf-armci
-[Known Issues]: #known-issues
- [Library Issues]: #library-issues
- [Compiler Issues]: #compiler-issues
   [GNU (gfortran)]: #compiler-issues-gnu
   [Cray (ftn)]: #compiler-issues-cray
   [Intel (ifort)]: #compiler-issues-intel
   [Numerical Algorithms Group (nagfor)]: #compiler-issues-nag
   [Portland Group (pgfortran)]: #compiler-issues-pg
   [IBM (xlf)]: #compiler-issues-ibm
-[Feature Coverage]: #feature-coverage
-[To-Do List]: #to-do-list
+  [forking the OpenCoarrays repository]: https://github.com/sourceryinstitute/opencoarrays/blob/master/STATUS.md#fork-destination-box
 
 [TS 18508]: http://isotc.iso.org/livelink/livelink?func=ll&objId=17181227&objAction=Open
 [opencoarrays module]: ./src/extensions/opencoarrays.F90
 [ABI]: https://gcc.gnu.org/onlinedocs/gfortran/Function-ABI-Documentation.html#Function-ABI-Documentation
-[pull requests via GitHub]: https://github.com/sourceryinstitute/opencoarrays.git
-[pull request via GitHub]: https://github.com/sourceryinstitute/opencoarrays.git
+[pull requests via GitHub]: https://github.com/sourceryinstitute/opencoarrays/compare
+[pull request via GitHub]: https://github.com/sourceryinstitute/opencoarrays/compare
 [OpenCoarrays Google Group]: https://groups.google.com/forum/#!forum/opencoarrays
 [Sourcery Store]: http://www.sourceryinstitute.org/store
 [Issues]: https://github.com/sourceryinstitute/opencoarrays/issues


### PR DESCRIPTION
 - Major cleanup to documentation
 - CAF_ABI.md needs further attention, esp. TODO lists
 - Added a proper CONTRIBUTING.md
 - Still need to add:
   - Developer guide for SI devs
   - CHANGELOG.md

Fixes #107 