### PR TITLE
Duplicates in sync images array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ if(opencoarrays_aware_compiler)
   add_mpi_test(co_max 4 ${tests_root}/unit/collectives/co_max_test)
   add_mpi_test(syncall 32 ${tests_root}/unit/sync/syncall)
   add_mpi_test(syncimages 32 ${tests_root}/unit/sync/syncimages)
+  add_mpi_test(duplicate_syncimages 8 ${tests_root}/unit/sync/duplicate_syncimages)
   add_mpi_test(co_reduce 4 ${tests_root}/unit/collectives/co_reduce_test)
 #  add_mpi_test(syncimages_status 32 ${tests_root}/unit/sync/syncimages_status)
 

--- a/src/libcaf.h
+++ b/src/libcaf.h
@@ -57,6 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #define STAT_UNLOCKED		0
 #define STAT_LOCKED		1
 #define STAT_LOCKED_OTHER_IMAGE	2
+#define STAT_DUP_SYNC_IMAGES    3
 #define STAT_STOPPED_IMAGE 	6000
 
 /* Describes what type of array we are registerring. Keep in sync with

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -1601,6 +1601,7 @@ PREFIX (sync_images) (int count, int images[], int *stat, char *errmsg,
                      int errmsg_len)
 {
   int ierr = 0, i=0, remote_stat = 0;
+  int dup = 0, j = 0;
   MPI_Status s;
 
   if (count == 0 || (count == 1 && images[0] == caf_this_image))
@@ -1609,6 +1610,16 @@ PREFIX (sync_images) (int count, int images[], int *stat, char *errmsg,
         *stat = 0;
       return;
     }
+
+  for(i=0;i<count;i++)
+    for(j=0;j<i;j++)
+      if(images[i] == images[j])
+	{
+	  ierr = STAT_DUP_SYNC_IMAGES;
+	  if(stat)
+	    *stat = ierr;
+	  goto sync_images_err_chk;
+	}
 
 #ifdef GFC_CAF_CHECK
   {

--- a/src/tests/unit/sync/CMakeLists.txt
+++ b/src/tests/unit/sync/CMakeLists.txt
@@ -4,6 +4,9 @@ target_link_libraries(syncall OpenCoarrays)
 add_executable(syncimages syncimages.f90)
 target_link_libraries(syncimages OpenCoarrays)
 
+add_executable(duplicate_syncimages duplicate_syncimages.f90)
+target_link_libraries(duplicate_syncimages OpenCoarrays)
+
 #add_executable(syncimages_status syncimages_status.f90)
 #target_link_libraries(syncimages_status OpenCoarrays)
 

--- a/src/tests/unit/sync/duplicate_syncimages.f90
+++ b/src/tests/unit/sync/duplicate_syncimages.f90
@@ -1,0 +1,47 @@
+! syncimages test
+!
+! Copyright (c) 2012-2014, Sourcery, Inc.
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!     * Redistributions of source code must retain the above copyright
+!       notice, this list of conditions and the following disclaimer.
+!     * Redistributions in binary form must reproduce the above copyright
+!       notice, this list of conditions and the following disclaimer in the
+!       documentation and/or other materials provided with the distribution.
+!     * Neither the name of the Sourcery, Inc., nor the
+!       names of its contributors may be used to endorse or promote products
+!       derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL SOURCERY, INC., BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+!
+program duplicate_syncimages
+  implicit none
+
+  integer :: me,i,array(4)
+  integer :: stat = 0
+
+  me = this_image()
+
+  if(me == 1) then
+     array(1) = 5; array(2) = 6; array(3) = 7; array(4) = 5
+     sync images(array,stat=stat)
+     if(stat == 3) then
+        print *,"Test passed."
+     else
+        print *,"Test failed."
+     endif
+  endif
+
+  sync all
+
+end program


### PR DESCRIPTION
The list of images passed to sync images cannot contain duplicates. This patch checks this condition.
Test case included.