### PR TITLE
Add OFP as a git submodule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,4 +27,5 @@ install_prerequisites/build text
 .pullapprove.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmodules export-ignore
 developer-scripts export-ignore

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/OFP"]
+	path = vendor/OFP
+	url = git://github.com/OpenFortranProject/open-fortran-parser.git

--- a/developer-scripts/git-hooks/commit-msg
+++ b/developer-scripts/git-hooks/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # An example hook script to check the commit log message.
 # Called by "git commit" with one argument, the name of the file
@@ -77,7 +77,8 @@ test "" = "$(grep '^Signed-off-by: ' "$1" |
 # Check that the first line of the commit starts with a
 # capitalized letter.
 if ! (head -n 1 $1 | grep '^[A-Z]' &>/dev/null ); then
-    echo >&2 "First word of commit message must be a capitalized imperative verb.\n"
+    echo >&2 "First word of commit message must be a capitalized imperative verb."
+    echo ""
     let status=1
 fi
 
@@ -89,23 +90,28 @@ cat $1 | \
 	nchars=$(wc -c <<<$line)
 	if [[ "$ln" -eq "1" ]]; then
 	    if [[ "$nchars" -gt "51" ]]; then
-		echo >&2 "First line of commit message too long ($nchars > 50 chars)\n"
+		echo >&2 "First line of commit message too long ($nchars > 50 chars)"
+		echo ""
 		let status=1
 	    fi
 	elif [[ "$ln" -eq "2" ]]; then
 	    if [[ "$nchars" -gt "1" ]] && ! grep '^#' <<<"$line" >/dev/null; then
-		echo >&2 "Second line of commit message not blank\n"
+		echo >&2 "Second line of commit message not blank"
+		echo ""
 		let status=1
 	    fi
 	else
 	    if [[ "$nchars" -gt "72" ]]; then
-		echo >&2 "Line $ln of commit message too long ($nchars > 72 chars)\n"
+		echo >&2 "Line $ln of commit message too long ($nchars > 72 chars)"
+		echo ""
 		let status=1
 	    fi
 	fi
     done
 
-if [[ $status != 0 ]]; then
-    error_message
-    exit 1
+if [[ $status = 0 ]]; then
+    exit 0
 fi
+
+error_message
+exit 1

--- a/developer-scripts/git-hooks/pre-commit
+++ b/developer-scripts/git-hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # An example hook script to verify what is about to be committed.
 # Called by "git commit" with no arguments.  The hook should
@@ -71,15 +71,18 @@ for f in $(git diff-index --name-status --cached $against | grep -v ^D | cut -c3
     if [[ "$f" =~ ([.](h|m|c|rb|sh|py|txt|md|f90|F90|cmake|x64|csh)|makefile|Makefile)$ ]] ||
        head -n 1 | grep '^#!/'; then
 	if ! ends_with_newline "$f"; then
-	    echo &>2 "No newline at end of file: $f\n"
+	    echo &>2 "No newline at end of file: $f"
+	    echo ""
 	    let status=1
 	fi
     fi
 done
 
 # If there are whitespace errors, print the offending file names and fail.
-git diff-index --check --cached $against -- || let status=1
+git diff-index --check --cached $against -- || (let status=1 echo 'white space violations found')
 
-if [[ $status != 0 ]]; then
-    exit 1
+if [[ $status = 0 ]]; then
+    exit 0
 fi
+
+exit 1

--- a/developer-scripts/setup-git.sh
+++ b/developer-scripts/setup-git.sh
@@ -8,7 +8,8 @@ if [[ "$1" ]]; then
 	echo "WARNING: Settings will be applied globally. This may over-write some of your global git settings."
 	read -p "Press Ctrl-C to abort, and try again without \`--global\` or press any key to contibue" foo
     else
-	echo -e "Usage: $0 [--global] [--help]\n"
+	echo "Usage: $0 [--global] [--help]"
+	echo ""
 	echo "This script is to configure your git environment"
 	echo "For contributing to OpenCoarrays. The \`--help\`"
 	echo "flag will print this message. The \`--global\`"
@@ -27,7 +28,8 @@ system=$(uname)
 if [[ "X$system" == "XDarwin" || "X$system" == "XLinux" ]]; then
     git config $flags core.autocrlf input
 else # assume windows
-    git fonfig $flags core.autocrlf true
+# Safer, maybe, to just not do anything...
+#    git fonfig $flags core.autocrlf true
 fi
 
 git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,blank-at-eof
@@ -35,6 +37,17 @@ git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,b
 git config $flags apply.whitespace fix
 
 git config $flags color.diff.whitespace red reverse
+
+# Lets update some stuff to work better with submodules (for OFP)
+git config $flags diff.submodule log
+
+git config $flags status.submodulesummary 1
+
+git config $flags push.recurseSubmodules check
+
+git config alias.sdiff '!'"git diff && git submodule foreach 'git diff'"
+git config alias.spush 'push --recurse-submodules=on-demand'
+git config alias.supdate 'submodule update --remote --merge'
 
 gitroot="$(git rev-parse --show-toplevel)"
 echo "WARNING: About to install and overwrite project level githooks in $gitroot/.git/hooks"


### PR DESCRIPTION
See #119 as well.

 I have updated the git setup/config scripts to help ease working with
 submodules. I suggest re-running the git setup developer script.

 Submodules are a somewhat complicated beast, but I really think for our usage,
 pulling in OFP via submodule sounds like the best route. If we change our minds
 once we start hacking with OFP, we'll be able to investigate other alternative
 integration strategies. (Subtree merge, committing code directly, scripted external
 dependency, etc.)

 To begin reading up: https://git-scm.com/book/en/v2/Git-Tools-Submodules