### PR TITLE
Add OFP as git submodule connected to #119

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,4 +27,5 @@ install_prerequisites/build text
 .pullapprove.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmodules export-ignore
 developer-scripts export-ignore

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/OFP"]
+	path = vendor/OFP
+	url = git://github.com/OpenFortranProject/open-fortran-parser.git

--- a/developer-scripts/setup-git.sh
+++ b/developer-scripts/setup-git.sh
@@ -8,7 +8,8 @@ if [[ "$1" ]]; then
 	echo "WARNING: Settings will be applied globally. This may over-write some of your global git settings."
 	read -p "Press Ctrl-C to abort, and try again without \`--global\` or press any key to contibue" foo
     else
-	echo -e "Usage: $0 [--global] [--help]\n"
+	echo "Usage: $0 [--global] [--help]"
+	echo ""
 	echo "This script is to configure your git environment"
 	echo "For contributing to OpenCoarrays. The \`--help\`"
 	echo "flag will print this message. The \`--global\`"
@@ -27,7 +28,8 @@ system=$(uname)
 if [[ "X$system" == "XDarwin" || "X$system" == "XLinux" ]]; then
     git config $flags core.autocrlf input
 else # assume windows
-    git fonfig $flags core.autocrlf true
+# Safer, maybe, to just not do anything...
+#    git fonfig $flags core.autocrlf true
 fi
 
 git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,blank-at-eof
@@ -35,6 +37,17 @@ git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,b
 git config $flags apply.whitespace fix
 
 git config $flags color.diff.whitespace red reverse
+
+# Lets update some stuff to work better with submodules (for OFP)
+git config $flags diff.submodule log
+
+git config $flags status.submodulesummary 1
+
+git config $flags push.recurseSubmodules check
+
+git config alias.sdiff '!'"git diff && git submodule foreach 'git diff'"
+git config alias.spush 'push --recurse-submodules=on-demand'
+git config alias.supdate 'submodule update --remote --merge'
 
 gitroot="$(git rev-parse --show-toplevel)"
 echo "WARNING: About to install and overwrite project level githooks in $gitroot/.git/hooks"


### PR DESCRIPTION
 - Put OFP into vendor subdir -- conventional SCM practice
 - Make sure we don't archive git stuff
 - Update git settings/setup script for submodule help

Git submodule may be unnecessary, OFP appears to need some cleanup and install/build system love