### PR TITLE
Revert "Add OFP as git submodule connected to #119"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,5 +27,4 @@ install_prerequisites/build text
 .pullapprove.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.gitmodules export-ignore
 developer-scripts export-ignore

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/OFP"]
-	path = vendor/OFP
-	url = git://github.com/OpenFortranProject/open-fortran-parser.git

--- a/developer-scripts/setup-git.sh
+++ b/developer-scripts/setup-git.sh
@@ -8,8 +8,7 @@ if [[ "$1" ]]; then
 	echo "WARNING: Settings will be applied globally. This may over-write some of your global git settings."
 	read -p "Press Ctrl-C to abort, and try again without \`--global\` or press any key to contibue" foo
     else
-	echo "Usage: $0 [--global] [--help]"
-	echo ""
+	echo -e "Usage: $0 [--global] [--help]\n"
 	echo "This script is to configure your git environment"
 	echo "For contributing to OpenCoarrays. The \`--help\`"
 	echo "flag will print this message. The \`--global\`"
@@ -28,8 +27,7 @@ system=$(uname)
 if [[ "X$system" == "XDarwin" || "X$system" == "XLinux" ]]; then
     git config $flags core.autocrlf input
 else # assume windows
-# Safer, maybe, to just not do anything...
-#    git fonfig $flags core.autocrlf true
+    git fonfig $flags core.autocrlf true
 fi
 
 git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,blank-at-eof
@@ -37,17 +35,6 @@ git config $flags core.whitespace trailing-space,space-before-tab,blank-at-eol,b
 git config $flags apply.whitespace fix
 
 git config $flags color.diff.whitespace red reverse
-
-# Lets update some stuff to work better with submodules (for OFP)
-git config $flags diff.submodule log
-
-git config $flags status.submodulesummary 1
-
-git config $flags push.recurseSubmodules check
-
-git config alias.sdiff '!'"git diff && git submodule foreach 'git diff'"
-git config alias.spush 'push --recurse-submodules=on-demand'
-git config alias.supdate 'submodule update --remote --merge'
 
 gitroot="$(git rev-parse --show-toplevel)"
 echo "WARNING: About to install and overwrite project level githooks in $gitroot/.git/hooks"


### PR DESCRIPTION
Reverts sourceryinstitute/opencoarrays#129

 - The wrong git submodule was added. Should have been OpenFortranProject/ofp-sdf
 - We will consume OFP as an external dependency, so don't need to sub-module it