### PR TITLE
Fix issue #123 build ftp fails on linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -312,11 +312,11 @@ find_or_install()
       export CC=$package_install_path/bin/gcc
       export CXX=$package_install_path/bin/g++
       if [[ -z "$LD_LIBRARY_PATH" ]]; then
-        echo "$this_script: export LD_LIBRARY_PATH=$package_install_path/lib/"
-                            export LD_LIBRARY_PATH=$package_install_path/lib/
+        echo "$this_script: export LD_LIBRARY_PATH=$package_install_path/lib64/"
+                            export LD_LIBRARY_PATH=$package_install_path/lib64/
       else
-        echo "$this_script: export LD_LIBRARY_PATH=$package_install_path/lib/:$LD_LIBRARY_PATH"
-                            export LD_LIBRARY_PATH=$package_install_path/lib/:$LD_LIBRARY_PATH
+        echo "$this_script: export LD_LIBRARY_PATH=$package_install_path/lib64/:$LD_LIBRARY_PATH"
+                            export LD_LIBRARY_PATH=$package_install_path/lib64/:$LD_LIBRARY_PATH
       fi
       # Remove $package from the dependency stack
       stack_pop dependency_pkg package_done
@@ -676,9 +676,9 @@ find_or_install()
           echo "$this_script: export CXX=$package_install_path/bin/g++"
                               export CXX="$package_install_path/bin/g++"
           if [[ -z "$LD_LIBRARY_PATH" ]]; then
-            export LD_LIBRARY_PATH="$package_install_path/lib/"
+            export LD_LIBRARY_PATH="$package_install_path/lib64/"
           else
-            export LD_LIBRARY_PATH="$package_install_path/lib/:$LD_LIBRARY_PATH"
+            export LD_LIBRARY_PATH="$package_install_path/lib64/:$LD_LIBRARY_PATH"
           fi
         elif [[ $package == "mpich" ]]; then
           echo "$this_script: export MPIFC=$package_install_path/bin/mpif90"
@@ -860,8 +860,15 @@ report_results()
       echo "  export PATH=\"$m4_install_path/bin\":\$PATH                        " >> setup.sh
       echo "fi                                                                   " >> setup.sh
     fi
-    setup_sh_location=$install_path
-    $SUDO mv setup.sh $install_path || setup_sh_location=${PWD}
+    opencoarrays_install_path=$install_path
+    if [[ -x "$opencoarrays_install_path/bin/caf" ]]; then
+      echo "if [[ -z \"\$PATH\" ]]; then                                         " >> setup.sh
+      echo "  export PATH=\"$opencoarrays_install_path/bin\"                     " >> setup.sh
+      echo "else                                                                 " >> setup.sh
+      echo "  export PATH=\"$opencoarrays_install_path/bin\":\$PATH              " >> setup.sh
+      echo "fi                                                                   " >> setup.sh
+    fi
+    $SUDO mv setup.sh $opencoarrays_install_path && setup_sh_location=$opencoarrays_install_path || setup_sh_location=${PWD}
     echo "*** Before using caf, cafrun, or build, please execute the following command ***"
     echo "*** or add it to your login script and launch a new shell (or the equivalent ***"
     echo "*** for your shell if you are not using a bash shell):                       ***"

--- a/install.sh
+++ b/install.sh
@@ -92,8 +92,6 @@ if [[ ! -x "$build_script" ]]; then
   echo "$this_script: $build_script script does not exist or the user lacks executable permission for it."
   echo "$this_script: Please run this_script in the top-level OpenCoarrays source directory or set the"
   echo "$this_script: OPENCOARRAYS_SRC_DIR environment variable to the top-level OpenCoarrays source path."
-  echo "$this_script: If you have specified an installation directory that requires administrative privileges,"
-  echo "$this_script: please prepend 'sudo' or 'sudo -E' to your invocation of the script [exit 20]."
   exit 20
 fi
 
@@ -687,11 +685,6 @@ find_or_install()
                               export MPICC="$package_install_path/bin/mpicc"
           echo "$this_script: export MPICXX=$package_install_path/bin/mpicxx"
                               export MPICXX="$package_install_path/bin/mpicxx"
-         #if [[ -z "$LD_LIBRARY_PATH" ]]; then
-         #  export LD_LIBRARY_PATH="$package_install_path/lib/"
-         #else
-         #  export LD_LIBRARY_PATH="$package_install_path/lib/:$LD_LIBRARY_PATH"
-         #fi
         else
           printf "$this_script: WARNING: $package executable $executable installed correctly but the \n"
           printf "$this_script:          corresponding environment variable(s) have not been set. This \n"
@@ -814,9 +807,9 @@ report_results()
     gcc_install_path=`./build gcc --default --query-path`
     if [[ -d "$gcc_install_path/lib" ]]; then
       echo "if [[ -z \"\$LD_LIBRARY_PATH\" ]]; then                              " >> setup.sh
-      echo "  export LD_LIBRARY_PATH=\"$gcc_install_path/lib\"                   " >> setup.sh
+      echo "  export LD_LIBRARY_PATH=\"$gcc_install_path/lib64\"                   " >> setup.sh
       echo "else                                                                 " >> setup.sh
-      echo "  export LD_LIBRARY_PATH=\"$gcc_install_path/lib\":\$LD_LIBRARY_PATH " >> setup.sh
+      echo "  export LD_LIBRARY_PATH=\"$gcc_install_path/lib64\":\$LD_LIBRARY_PATH " >> setup.sh
       echo "fi                                                                   " >> setup.sh
     fi
     echo "                                                                       " >> setup.sh

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -184,7 +184,7 @@ set_url()
   if [[ $package_to_build == 'cmake' ]]; then
     major_minor="${version_to_build%.*}"
   elif [[ "$package_to_build" == "gcc" && "$version_to_build" != "trunk" ]]; then
-    gcc_url_head="ftp.gnu.org:/gnu/gcc/gcc-$version_to_build"
+    gcc_url_head="ftp.gnu.org:/gnu/gcc/gcc-$version_to_build/"
   else
     gcc_url_head="svn://gcc.gnu.org/svn/gcc/"
   fi

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -129,7 +129,7 @@ set_default_version()
 check_prerequisites()
 {
   if [[ "$package_to_build" == "gcc" && "$version_to_build" != "trunk" ]]; then
-    gcc_fetch="ftp"
+    gcc_fetch="ftp-url"
   else
     gcc_fetch="svn"
   fi
@@ -138,14 +138,14 @@ check_prerequisites()
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_download_mechanism=(
     "gcc:$gcc_fetch"
-    "wget:ftp"
+    "wget:ftp-url"
     "cmake:wget"
     "mpich:wget"
     "flex:wget"
-    "bison:wget"
+    "bison:ftp-url"
     "pkg-config:wget"
-    "make:ftp"
-    "m4:ftp"
+    "make:ftp-url"
+    "m4:ftp-url"
     "subversion:wget"
     "_unknown:0"
   )
@@ -184,7 +184,7 @@ set_url()
   if [[ $package_to_build == 'cmake' ]]; then
     major_minor="${version_to_build%.*}"
   elif [[ "$package_to_build" == "gcc" && "$version_to_build" != "trunk" ]]; then
-    gcc_url_head="http://ftpmirror.gnu.org/gcc/gcc-$version_to_build/"
+    gcc_url_head="ftp.gnu.org:/gnu/gcc/gcc-$version_to_build"
   else
     gcc_url_head="svn://gcc.gnu.org/svn/gcc/"
   fi
@@ -196,7 +196,7 @@ set_url()
     "mpich;http://www.mpich.org/static/downloads/$version_to_build/"
     "flex;http://sourceforge.net/projects/flex/files/"
     "make;ftp://ftp.gnu.org/gnu/make/"
-    "bison;http://ftp.gnu.org/gnu/bison/"
+    "bison;ftp.gnu.org:/gnu/bison/"
     "cmake;http://www.cmake.org/files/v$major_minor/"
     "subversion;http://www.eu.apache.org/dist/subversion/"
     "_unknown;0"
@@ -257,6 +257,37 @@ set_url()
 
 }
 
+ftp-url()
+{
+  ftp_mode=$1
+  url=$2
+
+  text_before_colon="${url%%:*}"
+  FTP_SERVER=$text_before_colon
+
+  text_after_colon="${url##*:}"
+  text_after_final_slash="${text_after_colon##*/}"
+  FILE_NAME=$text_after_final_slash
+
+  text_before_final_slash="${text_after_colon%/*}"
+  FILE_PATH="$text_before_final_slash"
+
+  USERNAME=anonymous
+  PASSWORD=""
+  echo "$this_script: starting anonymous download: ftp $ftp_mode $FTP_SERVER... cd $FILE_PATH... get $FILE_NAME"
+
+ftp $ftp_mode $FTP_SERVER <<Done-ftp
+user $USERNAME $PASSWORD
+cd $FILE_PATH
+passive
+binary
+get "$FILE_NAME"
+bye
+Done-ftp
+
+  echo "$this_script: finished anonymous ftp"
+}
+
 # Download pkg-config if the tar ball is not already in the present working directory
 download_if_necessary()
 {
@@ -307,7 +338,7 @@ download_if_necessary()
       fi
     elif [[ "$fetch" == "wget" ]]; then
       args=--no-check-certificate
-    elif [[ "$fetch" == "ftp" ]]; then
+    elif [[ "$fetch" == "ftp-url" ]]; then
       args=-n
     elif [[ "$fetch" == "git" ]]; then
       args=clone

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -257,6 +257,14 @@ set_url()
 
 }
 
+# Download a file from an anonymous ftp site 
+#
+# Usage:
+#    ftp-url  <ftp-mode>  <ftp-site-address>:/<path-to-file>/<file-name>
+#
+# Example:  
+#    ftp-url -n ftp.gnu.org:/gnu/m4/m4-1.4.17.tar.bz2
+
 ftp-url()
 {
   ftp_mode=$1
@@ -285,7 +293,7 @@ get "$FILE_NAME"
 bye
 Done-ftp
 
-  echo "$this_script: finished anonymous ftp"
+echo "$this_script: finished anonymous ftp"
 }
 
 # Download pkg-config if the tar ball is not already in the present working directory


### PR DESCRIPTION
This fixes #123 and improves the setup.sh file that install.sh creates.  When install.sh builds prerequisites from source, "source setup.sh" sets LD_LIBRARY_PATH correctly for both 32- and 64-bit builds on Linux and OS X and it adds gfortran/gcc/g++ to PATH and correctly detects when to add m4 to the PATH.  