### PR TITLE
Update copyright year for files touched in 2016

### DIFF
--- a/COPYRIGHT-BSD3
+++ b/COPYRIGHT-BSD3
@@ -4,8 +4,8 @@
     interface, and compiler wrapper.
 
  OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
- Copyright (c) 2015, Sourcery, Inc.
- Copyright (c) 2015, Sourcery Institute
+ Copyright (c) 2015-2016, Sourcery, Inc.
+ Copyright (c) 2015-2016, Sourcery Institute
  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/dependency_tree/gitkeep.sh
+++ b/doc/dependency_tree/gitkeep.sh
@@ -14,8 +14,8 @@ use_case=\
     command 'tree opencoarrays'."
 #
 # OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
-# Copyright (c) 2015, Sourcery, Inc.
-# Copyright (c) 2015, Sourcery Institute
+# Copyright (c) 2015, 2016, Sourcery, Inc.
+# Copyright (c) 2015, 2016, Sourcery Institute
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/install_prerequisites/acceptable_compiler.f90
+++ b/install_prerequisites/acceptable_compiler.f90
@@ -5,8 +5,8 @@
 !    OpenCoarrays-aware version
 !
 ! OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
-! Copyright (c) 2015, Sourcery, Inc.
-! Copyright (c) 2015, Sourcery Institute
+! Copyright (c) 2015, 2016, Sourcery, Inc.
+! Copyright (c) 2015, 2016, Sourcery Institute
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without modification,

--- a/install_prerequisites/build
+++ b/install_prerequisites/build
@@ -493,8 +493,8 @@ elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
   # Print script copyright if invoked with -v, -V, or --version argument
   echo ""
   echo "OpenCoarrays prerequisites Build Script"
-  echo "Copyright (C) 2015 Sourcery, Inc."
-  echo "Copyright (C) 2015 Sourcery Institute"
+  echo "Copyright (C) 2015-2016 Sourcery, Inc."
+  echo "Copyright (C) 2015-2016 Sourcery Institute"
   echo ""
   echo "$this_script comes with NO WARRANTY, to the extent permitted by law."
   echo "You may redistribute copies of $this_script under the terms of the"

--- a/src/extensions/caf-foot
+++ b/src/extensions/caf-foot
@@ -72,7 +72,7 @@ link_args="-fcoarray=lib -lcaf_mpi"
 if [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
     echo ""
     echo "OpenCoarrays Coarray Fortran Compiler Wrapper (caf version $caf_version)"
-    echo "Copyright (C) 2015 Sourcery, Inc."
+    echo "Copyright (C) 2015-2016 Sourcery, Inc."
     echo ""
     echo "OpenCoarrays comes with NO WARRANTY, to the extent permitted by law."
     echo "You may redistribute copies of OpenCoarrays under the terms of the"

--- a/src/extensions/caf-head
+++ b/src/extensions/caf-head
@@ -5,7 +5,7 @@
 # Invokes the chosen Fortran compiler with the received command-line
 # arguments. 
 #
-# Copyright (c) 2015, Sourcery, Inc.
+# Copyright (c) 2015-2016, Sourcery, Inc.
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/src/extensions/cafrun-foot
+++ b/src/extensions/cafrun-foot
@@ -30,7 +30,7 @@ if [ $# == 0 ]; then
 elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
   echo ""
   echo "OpenCoarrays Coarray Fortran Executable Launcher (caf version $caf_version)"
-  echo "Copyright (C) 2015 Sourcery, Inc."
+  echo "Copyright (C) 2015-2016 Sourcery, Inc."
   echo ""
   echo "OpenCoarrays comes with NO WARRANTY, to the extent permitted by law."
   echo "You may redistribute copies of OpenCoarrays under the terms of the"

--- a/src/extensions/cafrun-head
+++ b/src/extensions/cafrun-head
@@ -2,7 +2,7 @@
 #
 # Coarray Fortran (CAF) Executable Launcher
 #
-# Copyright (c) 2015, Sourcery, Inc.
+# Copyright (c) 2015-2016, Sourcery, Inc.
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/src/extensions/opencoarrays.F90
+++ b/src/extensions/opencoarrays.F90
@@ -1,6 +1,6 @@
 ! Fortran 2015 feature support for Fortran 2008 compilers
 !
-! Copyright (c) 2015, Sourcery, Inc.
+! Copyright (c) 2015-2016, Sourcery, Inc.
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without

--- a/src/libcaf-gfortran-descriptor.h
+++ b/src/libcaf-gfortran-descriptor.h
@@ -1,6 +1,6 @@
 /* One-sided MPI implementation of Libcaf
 
-Copyright (c) 2012-2015, Sourcery, Inc.
+Copyright (c) 2012-2016, Sourcery, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/libcaf.h
+++ b/src/libcaf.h
@@ -1,6 +1,6 @@
 /* One-sided MPI implementation of Libcaf
 
-Copyright (c) 2012-2015, Sourcery, Inc.
+Copyright (c) 2012-2016, Sourcery, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -1,6 +1,6 @@
 /* One-sided MPI implementation of Libcaf
 
-Copyright (c) 2012-2015, Sourcery, Inc.
+Copyright (c) 2012-2016, Sourcery, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/tests/performance/psnap/timemeasure.c
+++ b/src/tests/performance/psnap/timemeasure.c
@@ -1,6 +1,6 @@
 /* PSNAP Test: timemeausure.c
 
-  Copyright (c) 2012-2015, Sourcery, Inc.
+  Copyright (c) 2012-2016, Sourcery, Inc.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/tests/unit/collectives/co_broadcast.F90
+++ b/src/tests/unit/collectives/co_broadcast.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2012-2015, Sourcery, Inc.
+! Copyright (c) 2012-2016, Sourcery, Inc.
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without

--- a/src/tests/unit/collectives/co_max.F90
+++ b/src/tests/unit/collectives/co_max.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2012-2015, Sourcery, Inc.
+! Copyright (c) 2012-2016, Sourcery, Inc.
 ! All rights reserved.
 !
 ! Unit tests for co_max: verify parallel, collective maximum

--- a/src/tests/unit/collectives/co_min.F90
+++ b/src/tests/unit/collectives/co_min.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2012-2015, Sourcery, Inc.
+! Copyright (c) 2012-2016, Sourcery, Inc.
 ! All rights reserved.
 !
 ! Unit tests for co_min: verify parallel, collective minimum

--- a/src/tests/unit/collectives/co_reduce.F90
+++ b/src/tests/unit/collectives/co_reduce.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2012-2015, Sourcery, Inc.
+! Copyright (c) 2012-2016, Sourcery, Inc.
 ! All rights reserved.
 !
 ! Unit tests for co_min: verify parallel, collective minimum

--- a/src/tests/unit/collectives/co_sum.F90
+++ b/src/tests/unit/collectives/co_sum.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2012-2015, Sourcery, Inc.
+! Copyright (c) 2012-2016, Sourcery, Inc.
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
 Fixes #130

Find files with `2015` and have been modified since December 31, 2015:

```
git grep --name-only 2015 $(git log --pretty=format:%H --since="12/31/2015") | \
    cut -d : -f 2 | sort | uniq | \
    while read line; do \
       grep -Hn 2015 $line; \
    done > 2015-refs.ack
```

Then open `2015-refs.ack` in Emacs and `M-x compilation-mode` to jump to the file and line easily