### PR TITLE
:bath: Cleanup add-ofp branch

### DIFF
--- a/3rd-party-tools/open-fortran-parser-sdf/trans/CMakeLists.txt
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/CMakeLists.txt
@@ -1,0 +1,5 @@
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Makefile ${CMAKE_BINARY_DIR}/bin_staging/transpiler/Makefile COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/caf-lower.str ${CMAKE_BINARY_DIR}/bin_staging/transpiler/caf-lower.str COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fast-to-ocaf.str ${CMAKE_BINARY_DIR}/bin_staging/transpiler/fast-to-ocaf.str COPYONLY)
+
+install(DIRECTORY ${CMAKE_BINARY_DIR}/bin_staging/transpiler DESTINATION .)

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/Makefile
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/Makefile
@@ -1,0 +1,55 @@
+OFP_HOME  ?= $(HOME)/ofp-sdf
+
+include $(OFP_HOME)/make.inc
+
+SYNTAX_DIR = $(OFP_HOME)/fortran/syntax
+TRANS_DIR  = $(OFP_HOME)/fortran/trans
+PP_DIR     = $(OFP_HOME)/fortran/pp
+
+TBL     = $(SYNTAX_DIR)/Fortran.tbl
+TO_SIM  = $(TRANS_DIR)/ofp-simplify
+TO_FAST = $(TRANS_DIR)/ofp2fast
+TO_PP   = $(TRANS_DIR)/fast2pp
+PP      = $(PP_DIR)/Fortran.pp
+
+CFLAGS = $(ST_CFLAGS)  -I $(SYNTAX_DIR) -I $(TRANS_DIR)
+LDFLAGS = $(ST_LDFLAGS) -la stratego-lib
+
+## Fortran targets
+#  ---------------
+
+FC = ifort
+FCFLAGS = -g -I $(FOR_OCL_DIR)
+
+%.o: %.f90
+	@echo 'Building for OS $(OSUPPER) file: $<'
+	$(FC) -c $(FCFLAGS) -o $@ $<
+
+
+all : fast-to-ocaf
+
+caf-lower : caf-lower.str
+	$(ST_PATH)/strc -i caf-lower.str $(CFLAGS) $(LDFLAGS) --main io-caf-lower
+
+fast-to-ocaf : fast-to-ocaf.str
+	$(ST_PATH)/strc -i fast-to-ocaf.str $(CFLAGS) $(LDFLAGS) --main io-fast-to-ocaf
+
+check : fast-to-ocaf
+	@$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | ./fast-to-ocaf | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
+
+check-orig : fast-to-ocaf
+	@$(ST_PATH)/sglri -p $(TBL) -i testfile.f90.orig | $(TO_FAST) | ./fast-to-ocaf | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
+
+check-fast : fast-to-ocaf
+	$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | $(ST_PATH)/pp-aterm
+
+check-last : fast-to-ocaf
+	$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | ./fast-to-ocaf | $(ST_PATH)/pp-aterm
+
+check-lower : caf-lower
+	$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | ./caf-lower | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
+
+clean :
+	rm -f caf-lower caf-lower.c
+	rm -f fast-to-ocaf fast-to-ocaf.c
+	rm -f *.o *.lo *.dep

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/Makefile
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/Makefile
@@ -1,4 +1,23 @@
-OFP_HOME  ?= $(HOME)/ofp-sdf
+# Usage:
+#
+# If the OFP_HOME environment variable contains the path to the Open Fortran Parser,
+# then this Makefile transforms the coarray Fortran (CAF) source defined in SOURCE 
+# environment variable into the OpenCoarrays CAF (OCAF) dialect printed to the 
+# standard output.  Most commonly, one sets SOURCE on the command line that invokes
+# "make":
+#
+#    make SOURCE=foo.f90 check > ocaf-foo.f90
+#    make clean
+#
+# Alternatively, one can set OFP_HOME also in the "make" invocation: 
+#
+#    make SOURCE=foo.f90 OFP_HOME=/opt/ofp-sdf check >  ocaf-foo.f90
+#    make OFP_HOME=/opt/ofp-sdf clean
+#
+
+ifeq ($(OFP_HOME),)
+  $(error Usage: make SOURCE=foo.f90 OFP_HOME=/path/to/ofp-sdf check >  ocaf-foo.f90)
+endif
 
 include $(OFP_HOME)/make.inc
 
@@ -35,21 +54,21 @@ fast-to-ocaf : fast-to-ocaf.str
 	$(ST_PATH)/strc -i fast-to-ocaf.str $(CFLAGS) $(LDFLAGS) --main io-fast-to-ocaf
 
 check : fast-to-ocaf
-	@$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | ./fast-to-ocaf | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
+	@$(ST_PATH)/sglri -p $(TBL) -i $(SOURCE)| $(TO_FAST) | ./fast-to-ocaf | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
 
 check-orig : fast-to-ocaf
-	@$(ST_PATH)/sglri -p $(TBL) -i testfile.f90.orig | $(TO_FAST) | ./fast-to-ocaf | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
+	@$(ST_PATH)/sglri -p $(TBL) -i $(SOURCE).orig | $(TO_FAST) | ./fast-to-ocaf | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
 
 check-fast : fast-to-ocaf
-	$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | $(ST_PATH)/pp-aterm
+	$(ST_PATH)/sglri -p $(TBL) -i $(SOURCE) | $(TO_FAST) | $(ST_PATH)/pp-aterm
 
 check-last : fast-to-ocaf
-	$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | ./fast-to-ocaf | $(ST_PATH)/pp-aterm
+	$(ST_PATH)/sglri -p $(TBL) -i $(SOURCE) | $(TO_FAST) | ./fast-to-ocaf | $(ST_PATH)/pp-aterm
 
 check-lower : caf-lower
-	$(ST_PATH)/sglri -p $(TBL) -i testfile.f90 | $(TO_FAST) | ./caf-lower | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
+	$(ST_PATH)/sglri -p $(TBL) -i $(SOURCE) | $(TO_FAST) | ./caf-lower | $(TO_PP) | $(ST_PATH)/ast2text -p $(PP)
 
 clean :
 	rm -f caf-lower caf-lower.c
 	rm -f fast-to-ocaf fast-to-ocaf.c
-	rm -f *.o *.lo *.dep
+	rm -f *.o *.lo *.dep .libs/*.o

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/caf-lower.str
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/caf-lower.str
@@ -1,0 +1,74 @@
+module lope-lower
+
+imports
+   libstratego-lib
+   LOPe
+
+signature
+  constructors
+
+   OfpProgram  : A * B -> OfpProgram
+   OfpSpecPart : A     -> OfpSpecPart
+
+   zPartRef    : A * B * C -> zPartRef
+   zEntityDecl : A * B * C * D * E -> zEntityDecl
+
+strategies //=================START OF STRATEGIES============================
+
+  io-lope-lower =
+    io-wrap(lope-symbols)
+
+//  io-lope-lower =
+//    io-wrap(lope-lower)
+
+  lope-symbols =
+{ st :
+       ?OfpProgram(name, list)
+    ;  new-hashtable => st
+    ;  !OfpProgram(name, list)
+    ;  innermost(debug(!"DEBUG::::::  "); get-symbols(|st))
+//    ;  <hashtable-get(|"two")> st
+    ;  <hashtable-values> st
+    ;  debug(!"Symbols.....")
+}
+
+  lope-lower =
+      innermost(caf-lower-ast)
+    ; innermost(lope-lower-ast)
+    ; innermost(back-to-fast)
+
+rules //========================START OF RULES===============================
+
+get-symbols:  PartRef("get_subimage",args,no-image-selector())         -> "0"
+get-symbols(|st) =
+      ?OfpSpecPart(list)
+    ;  <hashtable-put(|"two", 2)> st
+    ; !["bb"]
+
+// remove image selector
+caf-lower-ast:  EntityDecl(obj,as,is,cs,init)   -> zEntityDecl(obj,as,[],cs,init)
+
+// transform THIS_IMAGE() to 0
+caf-lower-ast:  StructureConstructor(DerivedTypeSpec("THIS_IMAGE",[]),[]) -> "0"
+
+// transform get_subimage() to 0
+lope-lower-ast:  PartRef("get_subimage",args,no-image-selector())         -> "0"
+
+lope-lower-ast:  PartRef(name,ss,is)  -> zPartRef(name,ss,no-image-selector())
+
+lope-lower-ast:
+  ConcurrentExecControl(forall,image)           -> LoopConcurrentControl(forall)
+
+lope-lower-ast:
+  CoAllocateStmt(label,type,obj,list,image,eos) -> AllocateStmt(label,type,obj,list,eos)
+
+lope-lower-ast:
+  CoDeallocateStmt(label,obj,list,image,eos)    -> DeallocateStmt(label,obj,list,eos)
+
+lope-lower-ast:  [HaloAlloc(_)]                 -> []
+
+// Transform temporary ATerms back to original
+//
+
+back-to-fast:  zPartRef(name,ss,is)             -> PartRef(name,ss,is)
+back-to-fast:  zEntityDecl(obj,as,is,cs,init)   -> EntityDecl(obj,as,is,cs,init)

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/fast-to-ocaf.str
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/fast-to-ocaf.str
@@ -1,0 +1,544 @@
+module fast-to-ocaf
+
+imports
+   libstratego-lib
+   FAST
+   ofp-simplify
+
+signature
+  constructors
+
+  ALLOCATED : ALLOCATED
+  INTERNAL  : INTERNAL
+
+  clMemObject : symbol -> clMemObject
+
+
+strategies //=================START OF STRATEGIES============================
+
+  io-fast-to-ocaf =
+    io-wrap(fast-to-ocaf)
+
+  fast-to-ocaf =
+{ st,lt,save
+        :  ?Program(units)
+        ;  new-hashtable => st
+        ;  new-hashtable => lt
+        ;  !Program(units)
+        ;  topdown(try(fast-get-symbols(|st)))
+        ;  topdown(try(ocaf-get-symbols(|st,lt)))
+        ;  bottomup(try(ocaf-add-calls(|st,lt)))
+        ;  topdown(try(fast-flatten-scope-parts))
+        ;  bottomup(try(caf-lower-ast))  => save
+        ;  !"--------------------------------------------------------------------------------------"
+        ;  debug()
+        ;  !save
+}
+
+
+rules //========================START OF RULES===============================
+
+// Local thread group size
+// TODO - make dependent on dim and device
+opencl-local-size =
+     ![IntVal("16"),IntVal("8"),IntVal("1")]
+
+opencl-arg-shape(|st) =
+     ?PartRef(symbol,no-section-subscripts(),_)
+  ;  <hashtable-get(|symbol)> st
+  ;  ?(type,attrs)
+  ;  <fetch-elem(?Dimension(shape))> attrs
+  ;  <map(fast-dim-size)> shape
+ <+  ![1,1,1]
+
+opencl-rank(|st) =
+     ?args
+  ;  <map(opencl-arg-rank(|st))> args
+  ;  <foldr(!1,max)> <id>
+
+opencl-arg-rank(|st) =
+     ?PartRef(symbol,no-section-subscripts(),_)
+  ;  <hashtable-get(|symbol)> st
+  ;  ?(type,attrs)
+  ;  <fetch-elem(?Dimension(shape))> attrs
+  ; <length> shape
+ <+  !1
+
+// FAST strategies (MOVE TO fortran/trans)
+// ---------------
+
+fast-var-name =
+     ?VarRef(name)        ;  !name
+ <+  ?VarDef(name)        ;  !name
+
+// Remove excess list elements inside of a Scope
+//   - occurs when a single statement is replaced by a list of statements
+fast-flatten-scope-parts =
+     ?Scope(decls,execs,funcs)
+  ;  !Scope(<flatten-list>decls, <flatten-list>execs, <flatten-list>funcs)
+
+fast-allocation-object =
+     ?Allocation(object,_,_)
+  ;  <fast-var-name> object
+
+// assume literals for now, otherwise get const from symbol table
+// TODO - use choice to use lb info
+fast-build-allocation-size(|st,obj) =
+     ?AllocateShapeSpec(no-lower-bound(),ub)
+  ;  !ub
+
+fast-dim-size =
+     ?Range(lb,ub)
+  ;  !Parens(Minus(ub,Parens(lb)))
+  ;  !Parens(Plus(<id>,"1"))
+
+// Size of a type in bytes
+// TODO - add other intrinsic types and support for kinds
+// TODO - could replace kind with size in bytes!!!!
+fast-type-size =
+     ?REAL()              ;  !"4"
+ <+  ?INTEGER()           ;  !"4"
+
+fast-mult-op =
+     ?(l,r)
+  ;  !Mult(l,r)
+
+fast-allocation-size(|st) =
+     ?symbol
+  ;  <hashtable-get(|symbol)> st
+  ;  ?(type,attrs)
+  ;  <fetch-elem(?Dimension(shape))> attrs
+  ;  <map(fast-dim-size)> shape
+  ;  <foldr(!"1",fast-mult-op)> <id>
+  ;  <fast-mult-op> (<fast-type-size>type,<id>)
+
+fast-fix-no-lower-bound =
+     ?no-lower-bound()
+  ;  !"1"
+
+fast-update-allocation-dim =
+     ?(Range(lb,ub),Range(_,_))
+  ;  !Range(lb,ub)
+
+fast-update-allocation-codim =
+     ?(Range(lb,ub),Range(_,_))
+  ;  !Range(lb,ub)
+
+// Update the symbol table with information from an allocate statement
+fast-update-allocation-symbol(|st) =
+{shape,coshape,attrs
+  :  topdown(try(fast-fix-no-lower-bound))
+  ;  ?Allocation(VarRef(obj),alloc_shape,alloc_coshape)
+  ;  <hashtable-get(|obj)> st
+  ;  ?(type,decl_attrs)
+  ;  <elem> (ALLOCATABLE(),decl_attrs)   // ensure this symbol is allocatable
+  ;  <fetch-elem(?Dimension(decl_shape))> decl_attrs
+  ;  <fetch-elem(?Codimension(decl_coshape))> decl_attrs
+  ;  <zip(fast-update-allocation-dim)>   (alloc_shape,  decl_shape)   =>   shape
+  ;  <zip(fast-update-allocation-codim)> (alloc_coshape,decl_coshape) => coshape
+  ;  <filter( try(?Dimension(_)   ; !Dimension(shape))     )> decl_attrs
+  ;  <filter( try(?Codimension(_) ; !Codimension(coshape)) )> <id>
+  ;  <filter( try(?ALLOCATABLE()  ; !ALLOCATED()) )> <id> => attrs
+  ;  <hashtable-put(|obj,(type,attrs))> st
+}
+
+fast-build-use-stmt =
+     ?module_name
+  ;  !UseStmt(no-label(), no-module-nature(), module_name, [])
+
+fast-build-type-decl(|type,attrs) =
+     ?object_name
+  ;  !TypeDeclarationStmt(  no-label()
+                          , type
+                          , attrs
+                          , [Var(object_name,type,no-init())]
+                         )
+
+fast-build-block(|decls,execs) =
+     !Block(no-label()
+          , no-name()
+          , Scope(decls,execs,[])
+          , EndBlockStmt(no-label(),no-name()))
+
+// Allocate memory on OpenCL device via call to createBuffer()
+opencl-build-create-buffer(|st,device) =
+     ?obj
+  ;  <fast-allocation-size(|st)> obj
+  ;  ![  AssignmentStmt(no-label(),VarDef("cl_size__"),<id>)
+       , AssignmentStmt(no-label(),<cl-wrap-name> obj
+          , FunctionReference("createBuffer"
+             , [device,"CL_MEM_READ_WRITE",VarRef("cl_size__")
+               ,"C_NULL_PTR"]))
+      ]
+
+// Deallocate memory on OpenCL device via call to releaseMemObject()
+opencl-build-release-buffer(|st,device) =
+    !AssignmentStmt(no-label(),VarDef("cl_status__")
+          , FunctionReference("releaseMemObject", [<cl-wrap-var> <id>]))
+
+// Create an OpenCL kernel object via call to createKernel
+//TODO - check selector against device to ensure they refer to same image
+opencl-build-create-kernel(|ct,device) =
+     ?obj
+  ;  <hashtable-get(|obj)> ct
+  ;  ?(kernel,DerivedType("CLKernel",[]),[]) {annotations}
+  ;  !AssignmentStmt(no-label(),kernel
+         , FunctionReference("createKernel",[<cl-wrap-name>device,<write-to-string>obj]))
+  ;  ![<id>]
+ <+  ![    ]
+
+// Create an OpenCL kernel object via call to createKernel
+//TODO - check selector against device to ensure they refer to same image
+opencl-build-set-kernel-args(|ct,device) =
+{kernel_arg_funcs
+  :  ?(obj,args)
+  ;  <hashtable-get(|obj)> ct
+  ;  ?(kernel,DerivedType("CLKernel",[]),[]) {annotations}
+//  ;  <lookup> ("args", annotations)
+  ;  <map(opencl-build-set-kernel-arg(|ct,kernel))> <add-indices> args  => kernel_arg_funcs
+  ;  <flatten-list> [kernel_arg_funcs]
+ <+  ![]
+}
+
+// Add an argument to an OpenCL kernel object via call to setKernelArg
+//
+// TODO-FIXME: need to check procedure interface for argument type if arg is an expression
+opencl-build-set-kernel-arg(|ct,kernel) =
+     ?(index, VarRef(arg))                                    // scalar variables
+  ;  !AssignmentStmt(no-label(),VarDef("cl_status__")
+         , FunctionReference("setKernelArg"
+              ,[kernel,<subti>(index,1),arg]))
+ <+  ?(index, PartRef(arg,_,selector))                        // array variables
+  ;  <opencl-kernel-arg-type(|ct)> <hashtable-get(|arg)> ct
+  ;  !AssignmentStmt(no-label(),VarDef("cl_status__")
+         , FunctionReference("setKernelArg"
+              ,[kernel,<subti>(index,1),<id>]))
+ <+  ?(index, expr)                                            // assume int scalar
+  ;  !AssignmentStmt(no-label(),VarDef("focl_intvar__"), expr)
+  ;  <concat> [[<id>],
+               [AssignmentStmt(no-label(),VarDef("cl_status__")
+                   , FunctionReference("setKernelArg"
+                       ,[kernel,<subti>(index,1),VarRef("focl_intvar__")]))] ]
+
+opencl-kernel-arg-type(|ct) =
+     ?(cl_symbol, DerivedType("CLBuffer",_),_)
+  ;  !clMemObject(cl_symbol)
+
+
+// Utility strategies
+// ------------------
+
+cl-wrap-name =
+     is-string
+  ;  <conc-strings>("cl_", <id>, "_")
+ +>  ?VarRef(name)
+  ;  debug(!"CL_WRAP_NAME: ERROR isVarRef ------------------------------------------------")
+  ;  <conc-strings>("cl_", name, "_")
+
+cl-wrap-var =
+     ?VarRef(name)
+  ;  <conc-strings>("cl_", name, "_")
+ +>  ?VarDef(name)
+  ;  <conc-strings>("cl_", name, "_")
+ +>  is-string
+  ;  debug(!"CL_WRAP_VAR: ERROR is-string ------------------------------------------------")
+  ;  <conc-strings>("cl_", <id>, "_")
+
+ofp-ident
+  :  Var(ident,_,_) -> ident
+
+// add subimage device
+//
+ocaf-add-subimage-symbol(|ct,lhs) =
+     ?PartRef("get_subimage",args,no-image-selector())
+  ;  <hashtable-put(|<fast-var-name>lhs, (<cl-wrap-var>lhs,DerivedType("CLDevice",[]),[]))> ct
+  ;  !PartRef("get_subimage",args,no-image-selector())
+
+// Add a symbol to the symbol table
+st-add-symbol(|st,type,attrs) =
+     ?var
+  ;  <hashtable-put(|<ofp-ident>var,(type,attrs))> st
+
+// Add a symbol to the OCAF symbol table
+ct-add-symbol(|ct,type,attrs) =
+     ?symbol
+  ;  <hashtable-put(|symbol,(<cl-wrap-name>symbol,type,attrs))> ct
+
+ct-add-type-decl(|ct) =
+     ?ident
+  ;  <hashtable-get(|ident)> ct
+  ;  ?(clident,type,attrs)
+  ;  <fast-build-type-decl(|type,attrs)> clident
+
+
+// Build symbol table
+// ------------------
+
+// Add declared variables to symbol table
+fast-get-symbols(|st) =
+     ?TypeDeclarationStmt(label,type,attrs,vars)
+  ;  <map(st-add-symbol(|st,type,attrs))> vars
+  ;  !TypeDeclarationStmt(label,type,attrs,vars)
+
+// Update symbol table with information from allocate statements
+fast-get-symbols(|st) =
+     ?AllocateStmt(label,type,alloc_list,options)
+  ;  <map(fast-update-allocation-symbol(|st))> alloc_list
+  ;  !AllocateStmt(label,type,alloc_list,options)
+
+
+// Get symbols specifically relevant to OCAF
+// -----------------------------------------
+
+ocaf-get-symbols(|st,ct) =
+     ?AssignmentStmt(label,lhs,rhs)
+  ;  <ocaf-add-subimage-symbol(|ct,lhs)> rhs
+  ;  !AssignmentStmt(label,lhs,rhs)
+
+//ocaf-get-symbols(|st,ct) =
+//     ?CoAllocateStmt(label,type,alloc_list,options,image,eos)
+//  ;  <map(ct-add-symbol(|ct,DerivedType("CLBuffer",[]),[]))>
+//         <map(fast-allocation-object)> alloc_list
+//  ;  <map(fast-update-allocation-symbol(|st))> alloc_list
+//  ;  !CoAllocateStmt(label,type,alloc_list,options,image,eos)
+
+// Mark CallStmts having an ImageExecutionSelector (ImageExecStmt)
+//ocaf-get-symbols(|st,ct) =
+//     ?ImageExecStmt(label,name,args,image,eos)
+//  ;  <ocaf-get-stmt-symbol(|st,ct)> <id>
+//  ;  !ImageExecStmt(label,name,args,image,eos)
+
+// Mark DO CONCURRENT loops having an ImageExecutionSelector
+ocaf-get-symbols(|st,ct) =
+     ?BlockDoConstruct(begin,stmts,end)
+//  ;  !begin
+//  ;  ?NonlabelDoStmt(_,_,ConcurrentExecControl(_,image))
+//  ;  <map(ocaf-get-stmt-symbol(|st,ct))> stmts
+//  ;  !BlockDoConstruct(begin,stmts,end) {[("ImageExecutionSelector",<ocaf-subimage>image)]}
+
+// Unmark DO CONCURRENT loop (assumes no embedded do loops)
+//ocaf-get-symbols(|st,ct) =
+//     ?EndDoStmt(label,name)
+//  ;  <hashtable-get(|"ocaf_do_concurrent_tmp_")> ct
+//  ;  <hashtable-remove(|"ocaf_do_concurrent_tmp_")> ct
+//  ;  !EndDoStmt(label,name)
+
+// Add CONCURRENT subroutine names to OCAF symbols
+ocaf-get-stmt-symbol(|st,ct) =
+     ?CallStmt(label, name, args)
+  ;  <hashtable-put(|name,(<cl-wrap-name>name
+            , DerivedType("CLKernel",[])
+            , []){[("args",args)]})> ct
+  ;  !CallStmt(label, name, args)
+
+// Add ImageExecStmt subroutine name to OCAF symbols
+//ocaf-get-stmt-symbol(|st,ct) =
+//     ?ImageExecStmt(label,name,args,image,eos)
+//  ;  <hashtable-put(|name,(<cl-wrap-name>name
+//            , DerivedType("CLKernel",[])
+//            , []){[("args",args)]})> ct
+//  ;  !ImageExecStmt(label,name,args,image,eos)
+
+//ocaf-subimage =
+//     ?ImageExecutionSelector([VarRef(device)])
+//  ;  !device
+
+
+// Add ForOpenCL calls to the AST
+// ------------------------------
+
+// Replace get_subimage call with ForOpenCl counterpart
+//  - also create kernel calls here
+//     - TODO: fix for multiple devices
+ocaf-add-calls(|st,ct) =
+     ?AssignmentStmt(label,VarDef(lhs),PartRef("get_subimage",[arg],_))
+  ;  <flatten-list> <map(opencl-build-create-kernel(|ct,lhs))> <hashtable-keys> ct
+  ;  <concat> [[AssignmentStmt(label,VarDef(lhs),FunctionReference("get_subimage",
+                                      [arg,<cl-wrap-name>lhs]))], <id>]
+
+// Add variables associated with ForOpenCL calls
+//    focl_intvar__, cl_status__, cl_size__, ch_ng__(3)
+ocaf-add-calls(|st,ct) =
+     ?Scope(decls,execs,funcs)
+  ;  <concat> [[<fast-build-use-stmt>"opencoarrays"], decls]
+  ;  <concat> [<id>, <map(ct-add-type-decl(|ct))> <hashtable-keys()> ct]
+  ;  <concat> [<id>, [<fast-build-type-decl(|
+                          INTEGER(no-kind()),[])> "focl_intvar__"]]
+  ;  <concat> [<id>, [<fast-build-type-decl(|
+                          INTEGER(Kind(VarRef("c_size_t"))),[])> "cl_size__"]]
+  ;  <concat> [<id>, [TypeDeclarationStmt(no-label()
+                        , INTEGER(Kind(VarRef("c_size_t")))
+                        , []
+                        , [Var("cl_gwo__",
+                             ArrayType(INTEGER(Kind(VarRef("c_size_t")))
+                                     , [Range(no-lower-bound(), IntVal("3"))],[]), no-init())]
+                        )]]
+  ;  <concat> [<id>, [TypeDeclarationStmt(no-label()
+                        , INTEGER(Kind(VarRef("c_size_t")))
+                        , []
+                        , [Var("cl_gws__",
+                             ArrayType(INTEGER(Kind(VarRef("c_size_t")))
+                                     , [Range(no-lower-bound(), IntVal("3"))],[]), no-init())]
+                        )]]
+  ;  <concat> [<id>, [TypeDeclarationStmt(no-label()
+                        , INTEGER(Kind(VarRef("c_size_t")))
+                        , []
+                        , [Var("cl_lws__",
+                             ArrayType(INTEGER(Kind(VarRef("c_size_t")))
+                                     , [Range(no-lower-bound(), IntVal("3"))],[])
+                                          , Init(ArrayConstructor(AcSpec(no-type-spec()
+                                                                         ,<opencl-local-size>))))]
+                        )]]
+  ;  !Scope(<id>,  <concat> [[CallStmt(no-label(), "caf_init", [])], execs] ,funcs)
+
+// Replace coallocate statement with function call to alloc memory on device
+//ocaf-add-calls(|st,ct) =
+//{device
+//  :  ?CoAllocateStmt(label,type,alloc_list,options,image,eos)
+//  ;  <cl-wrap-name> <ocaf-subimage> image => device
+//  ;  <map(ct-add-symbol(|ct,DerivedType("CLBuffer",[]),[]))>
+//         <map(fast-allocation-object)> alloc_list
+//  ;  <map(fast-allocation-object)> alloc_list
+//  ;  <map(opencl-build-create-buffer(|st,device))> <id>
+//}
+
+// Replace codeallocate statement with function call to free memory on device
+//ocaf-add-calls(|st,ct) =
+//{device
+//  :  ?CoDeallocateStmt(label,dealloc_list,options,image,eos)
+//  ;  <cl-wrap-name> <ocaf-subimage> image => device
+//  ;  <map(opencl-build-release-buffer(|st,device))> dealloc_list
+//}
+
+// Replace assignment statements with memory transfer with read/writeBuffer
+ocaf-add-calls(|st,ct) =
+     ?AssignmentStmt(label,PartRef(var,no-section-subscripts(),[VarRef(device)]),VarRef(obj))
+  ;  <fast-allocation-size(|st)> var
+  ;  ![  AssignmentStmt(no-label(),VarDef("cl_size__"),<id>)
+       , AssignmentStmt(no-label(),VarDef("cl_status__")
+         , FunctionReference("writeBuffer"
+            ,[<cl-wrap-name>var,<conc-strings>("C_LOC(",obj,")"),VarRef("cl_size__")]))
+      ]
+ +>  ?AssignmentStmt(label,VarDef(var),PartRef(obj,no-section-subscripts(),[VarRef(device)]))
+  ;  <fast-allocation-size(|st)> obj
+  ;  ![  AssignmentStmt(no-label(),VarDef("cl_size__"),<id>)
+       , AssignmentStmt(no-label(),VarDef("cl_status__")
+         , FunctionReference("readBuffer"
+            ,[<cl-wrap-name>obj,<conc-strings>("C_LOC(",var,")"),VarRef("cl_size__")]))
+      ]
+
+// Add arguments to OpenCL kernels and run them; replacing DO CONCURRENT loop
+ocaf-add-calls(|st,ct) =
+{device,triplets
+  :  ?BlockDoConstruct(begin,stmts,end) {annotations}
+//  ;  <lookup> ("ImageExecutionSelector", annotations)  => device
+//  ;  <ocaf-forall-triplet> begin                       => triplets
+//  ;  ![]
+//  ;  <concat> [<id>, <map(opencl-build-calc-global-offset)> <add-indices> triplets]
+//  ;  <concat> [<id>, <map(opencl-build-calc-global-size  )> <add-indices> triplets]
+//  ;  <concat> [<id>, <map(opencl-replace-call-stmt(|ct,triplets))> stmts]
+//  ;  <concat> [<id>, <map(opencl-build-finish-kernel)> <map(fast-call-stmt-name)> stmts]
+//  ;  <flatten-list> <id>
+}
+
+// Add arguments to OpenCL kernels and run them; replacing ImageExecStmts
+//ocaf-add-calls(|st,ct) =
+//{device,rank
+//  :  ?ImageExecStmt(label,name,args,image,eos)
+//  ;  <ocaf-subimage> image    => device
+//  ;  <opencl-rank(|st)> args  => rank
+//  ;  <flatten-list>  <opencl-build-set-kernel-args(|ct,device)> (name,args)
+//  ;  <concat> [<id>, [<opencl-build-calc-global-offset-of-args(|st)> args]]
+//  ;  <concat> [<id>, [<opencl-build-calc-global-size-of-args  (|st)> args]]
+//  ;  <concat> [<id>,
+//               [AssignmentStmt(label,VarDef("cl_status__")
+//                  , FunctionReference("run",[<cl-wrap-name> name
+//                    ,rank, VarRef("cl_gwo__"), VarRef("cl_gws__"), VarRef("cl_lws__")]))]]
+//  ;  <concat> [<id>, [<opencl-build-finish-kernel> name]]
+//  ;  <flatten-list> <id>
+//}
+
+// Retrieve list of ForallHeader triplets
+//ocaf-forall-triplet =
+//     ?NonlabelDoStmt(_,_,ConcurrentExecControl(ForallHeader(_,triplet_list,_),_))
+//  ;  !triplet_list
+
+// Build AssignmentStmt calculating global offset from a ForallHeader triplet
+// TODO - incorporate step information
+opencl-build-calc-global-offset =
+     ?(index, ForallTripletSpec(var,lb,ub,step))
+  ;  !AssignmentStmt(no-label(),PartRef("cl_gwo__",[index],no-image-selector())
+         , Minus(lb,1))
+
+// Build AssignmentStmt calculating global offset from an arg list
+// TODO - this may not be urgent as OpenCL standard may only allow 0 offset for now
+opencl-build-calc-global-offset-of-args(|st) =
+     ?args
+  ;  !AssignmentStmt(no-label(),VarDef("cl_gwo__")
+        , ArrayConstructor(AcSpec(no-type-spec(),[IntVal("0"), IntVal("0"), IntVal("0")])))
+
+// Build AssignmentStmt calculating global size from a ForallHeader triplet
+// TODO - incorporate step information
+opencl-build-calc-global-size =
+     ?(index, ForallTripletSpec(var,lb,ub,step))
+  ;  <fast-dim-size> Range(lb,ub)
+  ;  !AssignmentStmt(no-label(),PartRef("cl_gws__",[index],no-image-selector()),<id>)
+
+// Build AssignmentStmts calculating global size from an arg list
+opencl-build-calc-global-size-of-args(|st) =
+     ?args
+  ;  !AssignmentStmt(no-label(),VarDef("cl_gws__")
+        , ArrayConstructor(AcSpec(no-type-spec(),[IntVal("1"), IntVal("1"), IntVal("1")])))
+  ;  <concat> [[<id>], <map(opencl-build-calc-global-size-of-arg(|st))> args]
+
+// Build AssignmentStmt calculating global size from an arg
+opencl-build-calc-global-size-of-arg(|st) =
+     ?arg
+  ;  <opencl-arg-shape(|st)> arg
+  ;  !AssignmentStmt(no-label(),VarDef("cl_gws__")
+        , FunctionReference("focl_global_size"
+            ,[<opencl-arg-rank(|st)>arg, "cl_lws__", "cl_gws__"
+               , ArrayConstructor(AcSpec(no-type-spec(),<id>))]))
+
+// Replace subroutine call with running the corresponding OpenCL kernel
+opencl-replace-call-stmt(|ct,bounds) =
+     ?CallStmt(label, name, args)
+  ;  <cl-wrap-name>name
+  ;  <flatten-list>  <opencl-build-set-kernel-args(|ct,"unknown-device")> (name,args)
+  ;  !AssignmentStmt(no-label(),VarDef("cl_status__")
+               , FunctionReference("run",[<cl-wrap-name>name
+                  , <length>bounds, VarRef("cl_gwo__"), VarRef("cl_gws__"), VarRef("cl_lws__")]))
+
+// Build the OpenCL kernel finish call
+opencl-build-finish-kernel =
+     ?name
+  ;  !AssignmentStmt(no-label(),VarDef("cl_status__")
+         , FunctionReference("clFinish",[<conc-strings>(<cl-wrap-name>name, "%commands")]))
+
+// Return the name of the call statement
+fast-call-stmt-name =
+     ?CallStmt(label, name, args)
+   ; !name
+
+// Lower CAF components to OCAF
+// ----------------------------
+caf-lower-ast =
+     ?SyncAllStmt(label, sync_stat_list)
+  ;  !CallStmt(label, "sync_all", sync_stat_list)
+
+caf-lower-ast =
+     ?Codimension(_)
+  ;  ![]
+
+caf-lower-ast =
+     ?EntityDecl(name,array_spec,coarray_spec,char_length,init)
+  ;  !EntityDecl(name,array_spec,          [],char_length,init)
+
+// This is just used to flatten the attribute list after removing Codimension attribute
+caf-lower-ast =
+     ?TypeDeclarationStmt(label,type,attrs,vars)
+  ;  !TypeDeclarationStmt(label,type,<flatten-list>attrs,vars)
+
+caf-lower-ast =
+     ?Allocation(var,shape,coshape)
+  ;  !Allocation(var,shape,     [])

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/fast-to-ocaf.str
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/fast-to-ocaf.str
@@ -369,13 +369,6 @@ ocaf-add-calls(|st,ct) =
   ;  <concat> [<id>, [TypeDeclarationStmt(no-label()
                         , INTEGER(Kind(VarRef("c_size_t")))
                         , []
-                        , [Var("cl_gwo__",
-                             ArrayType(INTEGER(Kind(VarRef("c_size_t")))
-                                     , [Range(no-lower-bound(), IntVal("3"))],[]), no-init())]
-                        )]]
-  ;  <concat> [<id>, [TypeDeclarationStmt(no-label()
-                        , INTEGER(Kind(VarRef("c_size_t")))
-                        , []
                         , [Var("cl_gws__",
                              ArrayType(INTEGER(Kind(VarRef("c_size_t")))
                                      , [Range(no-lower-bound(), IntVal("3"))],[]), no-init())]
@@ -389,7 +382,11 @@ ocaf-add-calls(|st,ct) =
                                           , Init(ArrayConstructor(AcSpec(no-type-spec()
                                                                          ,<opencl-local-size>))))]
                         )]]
-  ;  !Scope(<id>,  <concat> [[CallStmt(no-label(), "caf_init", [])], execs] ,funcs)
+  ;  !Scope(<id>, execs, funcs)
+  ;  ?Scope(decls2, execs2, funcs2)
+  ;  <concat> [[CallStmt(no-label(), "caf_init", [])], execs2]
+  ;  <concat> [<id>, [CallStmt(no-label(), "caf_finalize", [])]]
+  ;  !Scope(decls2, <id> ,funcs2)
 
 // Replace coallocate statement with function call to alloc memory on device
 //ocaf-add-calls(|st,ct) =

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/fast-to-ocaf.str
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/fast-to-ocaf.str
@@ -527,6 +527,10 @@ caf-lower-ast =
   ;  !CallStmt(label, "sync_all", sync_stat_list)
 
 caf-lower-ast =
+     ?SyncImagesStmt(label, image_set, sync_stat_list)
+  ;  !CallStmt(label, "sync_images", <concat>[[image_set],sync_stat_list] )
+
+caf-lower-ast =
      ?Codimension(_)
   ;  ![]
 

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/testfile.f90
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/testfile.f90
@@ -1,0 +1,5 @@
+program dijkstra_main
+
+  sync all
+
+end program

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/testfile.f90
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/testfile.f90
@@ -1,4 +1,0 @@
-integer :: ierr
-sync images(1,stat=ierr)
-call sync_images(1,stat=ierr)
-end

--- a/3rd-party-tools/open-fortran-parser-sdf/trans/testfile.f90
+++ b/3rd-party-tools/open-fortran-parser-sdf/trans/testfile.f90
@@ -1,5 +1,4 @@
-program dijkstra_main
-
-  sync all
-
-end program
+integer :: ierr
+sync images(1,stat=ierr)
+call sync_images(1,stat=ierr)
+end

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_subdirectory(src)
 add_subdirectory(install_prerequisites)
+add_subdirectory(3rd-party-tools/open-fortran-parser-sdf/trans)
 
 #-----------------------------------------------------
 # Publicize installed location to other CMake projects

--- a/install_prerequisites/build-ofp.sh
+++ b/install_prerequisites/build-ofp.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# build-ofp
+#
+# -- This script downloads and installs Open Fortran Praser and its prerequisites
+#
+# OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
+# Copyright (c) 2015-2016, Sourcery, Inc.
+# Copyright (c) 2015-2016, Sourcery Institute
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+#    list of conditions and the following disclaimer in the documentation and/or
+#    other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of their contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+this_script=`basename $0`
+
+# Download and uncompress the ofp-sdf tar ball
+echo "$this_script: Downloading ofp-sdf"
+wget https://dl.dropboxusercontent.com/u/7038972/ofp-sdf.tar.bz2
+if [[ -f ofp-sdf.tar.bz2 ]]; then
+  echo "$this_script: Download of ofp-sdf succeeded."
+else
+  echo "$this_script: Download of ofp-sdf failed."
+  exit 10
+fi
+echo "$this_script: Uncompressing ofp-sdf."
+tar xf ofp-sdf.tar.bz2
+if [[ -d "ofp-sdf" ]]; then
+  echo "$this_script: Decompression of ofp-sdf succeeded."
+  OFP_HOME=${PWD}/ofp-sdf
+else
+  echo "$this_script: Decompression of ofp-sdf failed."
+fi
+
+# Download and uncompress the aterm tar ball
+echo "$this_script: Downloading aterm"
+wget http://releases.strategoxt.org/strategoxt-0.17/aterm/aterm-2.5pre21238-26ra85lr/aterm-2.5.tar.gz
+echo "$this_script: Uncompressing sf2-bundle"
+if [[ -f "aterm-2.5.tar.gz" ]]; then
+  echo "$this_script: Download of aterm succeeded."
+else
+  echo "$this_script: Download of aterm failed. [exit 20]"
+  exit 20
+fi
+tar xf aterm-2.5.tar.gz
+if [[ -d "aterm-2.5" ]]; then
+  echo "$this_script: Decompression of aterm-2.5 succeeded."
+else
+  echo "$this_script: Decompression of aterm-2.5 failed."
+fi
+
+# Download and uncompress the sf2-bundle tar ball
+echo "$this_script: Downloading sf2-bundle"
+wget http://releases.strategoxt.org/strategoxt-0.17/sdf2-bundle/sdf2-bundle-2.4pre212034-1ax0hbra/sdf2-bundle-2.4.tar.gz
+if [[ -f "aterm-2.5.tar.gz" ]]; then
+  echo "$this_script: Download of sdf2-bundle succeeded."
+else
+  echo "$this_script: Download of sdf2-bundle failed. [exit 30]"
+  exit 30
+fi
+echo "$this_script: Uncompressing sf2-bundle"
+tar xf sdf2-bundle-2.4.tar.gz
+if [[ -d "sdf2-bundle-2.4" ]]; then
+  echo "$this_script: Decompression of sdf2-bundle-2.4 succeeded."
+else
+  echo "$this_script: Decompression of sdf2-bundle-2.4 failed. [exit 40]"
+  exit 40
+fi
+
+# Download and uncompress the strategoxt tar ball
+echo "$this_script: Downloading strategoxt-0.17"
+wget http://ftp.strategoxt.org/pub/stratego/StrategoXT/strategoxt-0.17/strategoxt-0.17.tar.gz
+echo "$this_script: Uncompressing strategoxt-0.17"
+tar xf strategoxt-0.17.tar.gz
+if [[ -d "strategoxt-0.17" ]]; then
+  echo "$this_script: Decompression of strategoxt-0.17 succeeded."
+else
+  echo "$this_script: Decompression of strategoxt-0.17 failed. [exit 50]"
+  exit 50
+fi
+
+# Build everything
+echo "Building parse table"
+cd $OFP_HOME/fortran/syntax
+make
+cd $OFP_HOME/fortran/trans
+make

--- a/src/extensions/caf2ocaf-foot.sh
+++ b/src/extensions/caf2ocaf-foot.sh
@@ -1,0 +1,56 @@
+cmd=`basename $0`
+
+usage()
+{
+    echo ""
+    echo " $cmd - Coarray Fortran (CAF)"
+    echo ""
+    echo " Usage:"
+    echo "    $cmd <caf-source-file>"
+    echo "    or"
+    echo "    $cmd [option] ..."
+    echo ""
+    echo " Options:"
+    echo "   --help, -h               Show this help message"
+    echo "   --version, -v, -V        Report version and copyright information"
+    echo ""
+    echo " Examples:"
+    echo ""
+    echo "   $cmd foo.f90"
+    echo "   $cmd -v"
+    echo "   $cmd --help"
+    echo ""
+    echo "Given a Fortran 2015 CAF source file, $cmd produces a semantically equivalent"
+    echo "program that uses a subset of Fortran supported any recently released Fortran "
+    echo "compilers.  The subset uses the opencoarrays module and is referred to as the" 
+    echo "OpenCoarrays CAF (OCAF) dialect."
+}
+
+# Print usage information if caf is invoked without arguments
+if [ $# == 0 ]; then
+  usage | less
+  exit 10
+fi
+
+
+if [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
+    echo ""
+    echo "OpenCoarrays Coarray Fortran Compiler Wrapper (caf version $caf_version)"
+    echo "Copyright (C) 2015-2016 Sourcery, Inc."
+    echo ""
+    echo "OpenCoarrays comes with NO WARRANTY, to the extent permitted by law."
+    echo "You may redistribute copies of OpenCoarrays under the terms of the"
+    echo "BSD 3-Clause License.  For more information about these matters, see"
+    echo "the file named COPYRIGHT-BSD3."
+    echo ""
+elif [[ $1 == '-w' || $1 == '--wrapping' || $1 == '--wraps' ]]; then
+  echo "caf wraps CAFC=$CAFC"
+elif [[ $1 == '-h' || $1 == '--help' ]]; then
+  # Print usage information
+  usage | less
+  exit 20
+else
+  export SOURCE=$1
+  export OFP_HOME=$ofp_dir
+  make -f $transpiler_dir/Makefile check
+fi

--- a/src/extensions/caf2ocaf-head.sh
+++ b/src/extensions/caf2ocaf-head.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# caf2ocaf
+#
+# -- Coarray Fortran (CAF) to OpenCoarrays Fortran (OCAF) Transpiler:
+#
+# Copyright (c) 2016, Sourcery, Inc.
+# Copyright (c) 2016, Sourcery Institute
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Sourcery, Inc., nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL SOURCERY, INC., BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+#

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -59,6 +59,21 @@ endif()
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../extensions/caf-foot FOOTER)
 file(APPEND "${compiler_wrapper}" "${FOOTER}")
 
+# Now we write the script that transforms CAF source into the OCAF dialect 
+# intended to support non-CAF compilers.
+set(exe_dir ${CMAKE_BINARY_DIR}/bin_staging)
+set(transpiler ${exe_dir}/caf2ocaf)
+install(
+    FILES "${transpiler}"
+    PERMISSIONS WORLD_EXECUTE WORLD_READ WORLD_WRITE OWNER_EXECUTE OWNER_READ OWNER_WRITE GROUP_EXECUTE GROUP_READ GROUP_WRITE
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/
+)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../extensions/caf2ocaf-head.sh CAF2OCAF_HEADER)
+file(WRITE  "${transpiler}" "${CAF2OCAF_HEADER}\n")
+file(APPEND "${transpiler}"  "caf_version=${PROJECT_VERSION}\n")
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../extensions/caf2ocaf-foot.sh CAF2OCAF_FOOTER)
+file(APPEND "${transpiler}" "${CAF2OCAF_FOOTER}")
+
 # Now we write the script that launches executable files produced from CAF codes
 set(caf_launcher ${exe_dir}/cafrun)
 install(

--- a/src/tests/source-transformation/co_sum.f90
+++ b/src/tests/source-transformation/co_sum.f90
@@ -1,0 +1,51 @@
+! co_sum.f90
+!
+! -- This program provides a test target for the Open Fortran Parser source
+!    transformation rules defined in 3rd-party-tools/open-fortran-parser-sdf
+!    to support compiling coarray Fortran (CAF) programs with non-CAF compilers
+!
+! OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
+! Copyright (c) 2016, Sourcery Inc.
+! Copyright (c) 2016, Sourcery Institute
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are
+! met:
+!
+! 1. Redistributions of source code must retain the above copyright
+! notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright
+! notice, this list of conditions and the following disclaimer in the
+! documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its
+! contributors may be used to endorse or promote products derived from
+! this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+! A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+! DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+program main
+  use iso_c_binding, only : c_int
+  implicit none
+  integer(c_int) :: i,me
+
+  ! Verify collective sum of integer data by tallying image numbers
+  me=this_image()
+  call co_sum(me)
+  if (me/=sum([(i,i=1,num_images())])) error stop "Test failed"
+
+  ! Wait for every image to pass the test
+  sync all
+  if (this_image()==1) print *, "Test passed."
+end program

--- a/src/tests/source-transformation/derivative.f90
+++ b/src/tests/source-transformation/derivative.f90
@@ -1,0 +1,61 @@
+! derivative.f90
+!
+! -- This program provides a test target for the Open Fortran Parser source
+!    transformation rules defined in 3rd-party-tools/open-fortran-parser-sdf
+!    to support compiling coarray Fortran (CAF) programs with non-CAF compilers
+!
+! OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
+! Copyright (c) 2016, Sourcery Inc.
+! Copyright (c) 2016, Sourcery Institute
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are
+! met:
+!
+! 1. Redistributions of source code must retain the above copyright
+! notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright
+! notice, this list of conditions and the following disclaimer in the
+! documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its
+! contributors may be used to endorse or promote products derived from
+! this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+! A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+! DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+program main
+  implicit none
+  real, allocatable :: f(:)[:],df_dx(:)
+  integer, parameter :: num_points=1024
+  real, parameter :: pi=acos(-1.),dx=2.*pi/num_points,tolerance=0.0001
+  integer :: my_num_points,i,my_first,my_last,left,right
+  integer, allocatable :: neighbors(:)
+  if (mod(num_points,num_images()) /= 0) error stop "not evenly divisible"
+  my_num_points=num_points/num_images()
+  my_first=(this_image()-1)*my_num_points + 1
+  my_last = my_first + my_num_points - 1
+  allocate(f(my_num_points)[*],df_dx(my_num_points))
+  f(1:my_num_points) = sin(([(i,i=my_first,my_last)]-1)*dx)
+  left  = merge(this_image()-1,num_images(),this_image()/=1)
+  right = merge(this_image()+1,1           ,this_image()/=num_images())
+  neighbors = merge([left],[left,right],left==right)
+  sync images(neighbors)
+  df_dx(1)                 = (f(2) - f(my_num_points)[left])/(2.*dx)
+  df_dx(2:my_num_points-1) = [ ((f(i+1) - f(i-1))/(2.*dx), i=2,my_num_points-1) ]
+  df_dx(my_num_points)     = (f(1)[right] - f(my_num_points-1))/(2.*dx)
+  if (any(abs(df_dx-cos([(i,i=my_first-1,my_last-1)]*dx))>tolerance)) error stop "inaccurate derivative"
+  sync all
+  if (this_image()==1) print *, "Test passed."
+end program

--- a/src/tests/source-transformation/transformed-co_sum.f90
+++ b/src/tests/source-transformation/transformed-co_sum.f90
@@ -1,0 +1,56 @@
+! transformed-co_sum.f90
+!
+! -- This program demonstrates the co_sum.f90 source manually transformed
+!    analogously to the expected automatic transformation by the rules
+!    defined in 3rd-party-tools/open-fortran-parser-sdf to support compiling
+!    coarray Fortran (CAF) programs with non-CAF compilers
+!
+! OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
+! Copyright (c) 2016, Sourcery Inc.
+! Copyright (c) 2016, Sourcery Institute
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are
+! met:
+!
+! 1. Redistributions of source code must retain the above copyright
+! notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright
+! notice, this list of conditions and the following disclaimer in the
+! documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its
+! contributors may be used to endorse or promote products derived from
+! this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+! A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+! DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+program main
+  use opencoarrays
+  use iso_c_binding, only : c_int
+  implicit none
+  integer(c_int) :: i,me
+
+  call caf_init()
+
+  ! Verify collective sum of integer data by tallying image numbers
+  me=this_image()
+  call co_sum(me)
+  if (me==sum([(i,i=1,num_images())])) call error_stop("Test failed")
+
+  ! Wait for every image to pass the test
+  call sync_all()
+  if (this_image()==1) print *, "Test passed."
+  call caf_finalize()
+end program

--- a/src/tests/source-transformation/transformed-derivative.f90
+++ b/src/tests/source-transformation/transformed-derivative.f90
@@ -1,0 +1,67 @@
+! transformed-derivative.f90
+!
+! -- This program demonstrates the derivative.f90 source manually transformed
+!    analogously to the expected automatic transformation by the rules
+!    defined in 3rd-party-tools/open-fortran-parser-sdf to support compiling
+!
+! OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
+! Copyright (c) 2016, Sourcery Inc.
+! Copyright (c) 2016, Sourcery Institute
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are
+! met:
+!
+! 1. Redistributions of source code must retain the above copyright
+! notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright
+! notice, this list of conditions and the following disclaimer in the
+! documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its
+! contributors may be used to endorse or promote products derived from
+! this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+! A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+! DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+program main
+  use opencoarrays
+  implicit none
+  real, allocatable :: df_dx(:)
+  type(coarray) :: f_coarray
+  integer, parameter :: num_points=1024
+  real, parameter :: pi=acos(-1.),dx=2.*pi/num_points,tolerance=0.0001
+  integer :: my_num_points,i,my_first,my_last,left,right
+  integer, allocatable :: neighbors(:)
+  call caf_init()
+  if (mod(num_points,num_images()) /= 0) error stop "not evenly divisible"
+  my_num_points=num_points/num_images()
+  my_first=(this_image()-1)*my_num_points + 1
+  my_last = my_first + my_num_points - 1
+  allocate(df_dx(my_num_points))
+  call f_coarray%caf_register(my_num_points) ! Allocate & call c_f_pointer(f_coarray%data,f_coarray%f_ptr,shape=[my_num_points])
+  f_coarray%f_ptr(1:my_num_points) = sin( ([(i,i=my_first,my_last)]-1)*dx)
+  left  = merge(this_image()-1,num_images(),this_image()/=1)
+  right = merge(this_image()+1,1           ,this_image()/=num_images())
+  neighbors = merge([left],[left,right],left==right)
+  call sync_images(neighbors)
+  df_dx(1)                =  ( f_coarray%f_ptr(2)         - f_coarray%caf_get(left,my_num_points))/(2.*dx)
+  df_dx(2:my_num_points-1)= [((f_coarray%f_ptr(i+1)       - f_coarray%f_ptr(i-1)                 )/(2.*dx),i=2,my_num_points-1)]
+  df_dx(my_num_points)    = (  f_coarray%caf_get(right,1) - f_coarray%f_ptr(my_num_points-1)     )/(2.*dx)
+  if (any(abs(df_dx-cos([(i,i=my_first-1,my_last-1)]*dx))>tolerance)) call error_stop("inaccurate derivative")
+  call sync_all()
+  if (this_image()==1) print *, "Test passed."
+  call f_coarray%caf_deregister()
+  call caf_finalize()
+end program


### PR DESCRIPTION
 This will supersede #137, but in terms of the changes applied to the codebase it is *the same*. Here is a list of the changes/transformations I made: :tophat: :sparkles: :rabbit2:
 - :octocat: Rebase `add-fop` branch onto `devel` (was based on `master`)
 - :memo: Re-word commits to follow the guidelines [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [here](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)
 - :x: Drop meaningless/useless/virtually-empty commits
 - :bug: Fixup/squash commits that were clearly fixing errors from previous commits (make it look like errors were never introduced, or items were never forgotten in individual commits)
 - ~~Add fallback location to find OFP_HOME if user forgets to pass this... probably not super helpful but worth a shot.~~
 - @rouson's latest additions add an error/warning message if OFP_HOME goes unset. This is better than having a default/fallback as discussed [below](https://github.com/sourceryinstitute/opencoarrays/pull/147#issuecomment-182578649)

Related to/implements #119 