### PR TITLE
Fix small CMake introspection issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ else()
 endif()
 
 if(gfortran_compiler)
-  set(CMAKE_REQUIRED_FLAGS "-fcoarray=single")
+  set(CMAKE_REQUIRED_FLAGS "-fcoarray=single -ffree-form")
 endif()
 include(CheckFortranSourceCompiles)
 CHECK_Fortran_SOURCE_COMPILES("

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,9 @@
 #
 # __________ Process command-line arguments and environment variables _____________
 
+# Make sure we really exit with correct status when piping function output
+set -o pipefail
+
 this_script=`basename $0`
 
 # Interpret the first command-line argument, if present, as the OpenCoarrays installation path.


### PR DESCRIPTION
 - Ensure that CheckFortranSourceCompiles can compile test/introspection code which is in F90 not f77
 - Make sure `install.sh` returns proper exit code... A bunch of the other scripts need to be examined for this defect too....