### PR TITLE
Corrected install.sh script's writing of setup.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,10 @@
 #    Alternatively, check the dependency stacks for the package before entering the
 #    main conditional blocks in find_or_install.
 #
+ 
+# Make sure we really exit with correct status when piping function output
+set -o pipefail
+
 # __________ Process command-line arguments and environment variables _____________
 
 this_script=`basename $0`

--- a/install.sh
+++ b/install.sh
@@ -54,9 +54,6 @@
 #
 # __________ Process command-line arguments and environment variables _____________
 
-# Make sure we really exit with correct status when piping function output
-set -o pipefail
-
 this_script=`basename $0`
 
 # Interpret the first command-line argument, if present, as the OpenCoarrays installation path.
@@ -799,15 +796,8 @@ report_results()
         echo "# $line" >> setup.sh
     done < "$opencoarrays_src_dir/LICENSE"
     echo "#                                                                      " >> setup.sh
-    echo "# Execute this script via the following commands:                      " >> setup.sh
-    echo "# cd $install_path                                                     " >> setup.sh
-    echo "# source setup.sh                                                      " >> setup.sh
-    echo "                                                                       " >> setup.sh
-    echo "if [[ -z \"\$PATH\" ]]; then                                           " >> setup.sh
-    echo "  export PATH=\"bin\"                                                  " >> setup.sh
-    echo "else                                                                   " >> setup.sh
-    echo "  export PATH=\"bin\":\$PATH                                           " >> setup.sh
-    echo "fi                                                                     " >> setup.sh
+    echo "# Execute this script via the following command:                       " >> setup.sh
+    echo "# source $install_path/setup.sh                                        " >> setup.sh
     echo "                                                                       " >> setup.sh
     gcc_install_path=`./build gcc --default --query-path`
     if [[ -x "$gcc_install_path/bin/gfortran" ]]; then


### PR DESCRIPTION
Removed an extraneous/erroneous "export PATH=.." that install.sh writes near the tope of setup.sh.
Corrected the instructions for how to use setup.sh so that sudo privileges won't be required.