### PR TITLE
Support gcc dev branch builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -125,12 +125,12 @@ fi
   emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 101]"
 
 [ ! -z "${arg_P}" ] && [ ! -z "${arg_U:-${arg_V:-${arg_B}}}" ] &&
-  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 103]"
+  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 102]"
 
 [ ! -z "${arg_U}" ] && [ ! -z "${arg_V:-${arg_B}}" ] &&
-  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 104]"
+  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 103]"
 
-[ ! -z "${arg_V}" ] && [ ! -z "${arg_B}}" ] &&
+[ ! -z "${arg_V}" ] && [ ! -z "${arg_B}" ] &&
   emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 104]"
 
 ### Print bootstrapped magic variables to STDERR when LOG_LEVEL

--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ trap cleanup_before_exit EXIT # The signal is specified here. Could be SIGINT, S
 [ -z "${LOG_LEVEL:-}" ] && emergency "Cannot continue without LOG_LEVEL. "
 
 # shellcheck disable=SC2154
-if [[ "${arg_v}" == "${__flag_present}" || "${arg_l}" == "${__flag_present}" || ! -z "${arg_P:-${arg_U:-${arg_V:-${arg_D}}}}" ]]; then
+if [[ "${arg_v}" == "${__flag_present}" || "${arg_l}" == "${__flag_present}" || ! -z "${arg_P:-${arg_U:-${arg_V:-${arg_D:-${arg_B}}}}}" ]]; then
    print_debug_only=7
    if [ "$(( LOG_LEVEL < print_debug_only ))" -ne 0 ]; then
      debug "Supressing info and debug messages: one of {-l, -v, -P, -U, -V, -D} present."
@@ -121,14 +121,17 @@ if [[ "${arg_v}" == "${__flag_present}" || "${arg_l}" == "${__flag_present}" || 
    fi
 fi
 
-[ ! -z "${arg_D}" ] && [ ! -z "${arg_P:-${arg_U:-${arg_V}}}" ] &&
-  emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 101]"
+[ ! -z "${arg_D}" ] && [ ! -z "${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}" ] &&
+  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 101]"
 
-[ ! -z "${arg_P}" ] && [ ! -z "${arg_U:-${arg_V}}" ] &&
-  emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 103]"
+[ ! -z "${arg_P}" ] && [ ! -z "${arg_U:-${arg_V:-${arg_B}}}" ] &&
+  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 103]"
 
-[ ! -z "${arg_U}" ] && [ ! -z "${arg_V}" ] &&
-  emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 104]"
+[ ! -z "${arg_U}" ] && [ ! -z "${arg_V:-${arg_B}}" ] &&
+  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 104]"
+
+[ ! -z "${arg_V}" ] && [ ! -z "${arg_B}}" ] &&
+  emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected). [exit 104]"
 
 ### Print bootstrapped magic variables to STDERR when LOG_LEVEL
 ### is at the default value (6) or above.
@@ -142,6 +145,8 @@ info "__os: ${__os}"
 info "__usage: ${__usage}"
 info "LOG_LEVEL: ${LOG_LEVEL}"
 
+info  "-b (--install-branch):   ${arg_b}"
+info  "-B (--list-branches):    ${arg_B}"
 info  "-c (--with-c):           ${arg_c}"
 info  "-C (--with-cxx):         ${arg_C}"
 info  "-d (--debug):            ${arg_d}"
@@ -231,7 +236,6 @@ source $opencoarrays_src_dir/prerequisites/install-functions/report_results.sh
 
 # ________________________________ Start of the Main Body ___________________________________
 
-
 if [[ "${arg_v}" == "${__flag_present}" || "${arg_V}" == "opencoarrays" ]]; then
 
   # Print script copyright if invoked with -v, -V, or --version argument
@@ -255,10 +259,11 @@ if [[ "${arg_v}" == "${__flag_present}" || "${arg_V}" == "opencoarrays" ]]; then
     echo "${opencoarrays_version//[[:space:]]/}"
   fi
 
-elif [[ ! -z "${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}" ||  "${arg_l}" == "${__flag_present}" ]]; then
+elif [[ ! -z "${arg_D:-${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}}" ||  "${arg_l}" == "${__flag_present}" ]]; then
 
   # Delegate to build.sh for the packages it builds
-  build_arg=${arg_D:-${arg_P:-${arg_U:-${arg_V:-${arg_p}}}}}
+  build_arg=${arg_B:-${arg_D:-${arg_P:-${arg_U:-${arg_V:-${arg_p}}}}}}
+  [ ! -z "${arg_B}" ] && build_flag="-B"
   [ ! -z "${arg_D}" ] && build_flag="-D"
   [ ! -z "${arg_P}" ] && build_flag="-P"
   [ ! -z "${arg_U}" ] && build_flag="-U"
@@ -284,7 +289,6 @@ elif [[ ! -z "${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}" ||  "${arg_l}" == "${__fla
   fi
 
 elif [[ "${arg_p:-}" == "opencoarrays" ]]; then
-
   
   cd prerequisites || exit 1
   installation_record=install-opencoarrays.log

--- a/install.sh-usage
+++ b/install.sh-usage
@@ -1,3 +1,5 @@
+  -b --branch [arg]           Install the specified repository development branch.
+  -B --list-branches [arg]    List the available branches in the specified package's repository.
   -c --with-c [arg]           Use specified C compiler. 
   -C --with-cxx [arg]         Use specified C++ compiler. 
   -d --debug                  Enable debug mode.

--- a/prerequisites/build-functions/download_if_necessary.sh
+++ b/prerequisites/build-functions/download_if_necessary.sh
@@ -32,7 +32,7 @@ download_if_necessary()
   else
     # The download mechanism is in the path.
     if [[ "${fetch}" == "svn" ]]; then
-      if [[ ${version_to_build} == '--avail' || ${version_to_build} == '-a' ]]; then
+      if [[ "${arg_B:-}" == "gcc" ]]; then
         args="ls"
       else
         args="checkout"
@@ -59,29 +59,29 @@ download_if_necessary()
     else
       package_source_directory="${package_name}-${version_to_build}"
     fi
-    info "Downloading ${package_name} ${version_to_build} to the following location:"
+    info "Downloading ${package_name} ${version_to_build-} to the following location:"
     info "${download_path}/${package_source_directory}"
     info "Download command: \"${fetch}\" ${args:-} ${package_url}"
     info "Depending on the file size and network bandwidth, this could take several minutes or longer."
     pushd "${download_path}"
     "${fetch}" ${args:-} ${package_url}
     popd
-    if [[ "${version_to_build}" == '--avail' || "${version_to_build}" == '-a' ]]; then
-      # In this case, args="ls" and the list of available versions has been printed so we can move on.
-      exit 1
-    fi
-    if [[ "${fetch}" == "svn" ]]; then
-      search_path="${download_path}/${version_to_build}"
+    if [[ ! -z "${arg_B:-}" ]]; then
+      return
     else
-      search_path="${download_path}/${url_tail}"
-    fi
-    if [ -f "${search_path}" ] || [ -d "${search_path}" ]; then
-      info "Download succeeded. The ${package_name} source is in the following location:"
-      info "${search_path}"
-    else
-      info "Download failed. The ${package_name} source is not in the following, expected location:"
-      info "${search_path}"
-      emergency "Aborting. [exit 110]"
+      if [[ "${fetch}" == "svn" ]]; then
+        search_path="${download_path}/${version_to_build}"
+      else
+        search_path="${download_path}/${url_tail}"
+      fi
+      if [[ -f "${search_path}" || -d "${search_path}" ]]; then
+        info "Download succeeded. The ${package_name} source is in the following location:"
+        info "${search_path}"
+      else
+        info "Download failed. The ${package_name} source is not in the following, expected location:"
+        info "${search_path}"
+        emergency "Aborting. [exit 110]"
+      fi
     fi
   fi
 }

--- a/prerequisites/build-functions/set_or_print_default_version.sh
+++ b/prerequisites/build-functions/set_or_print_default_version.sh
@@ -57,6 +57,6 @@ set_or_print_default_version()
 
  # Exit with error status and diagnostic output if empty default_version
  if [[ -z "${default_version:-}" ]]; then
-    emergency "Package ${package_name:-} not recognized.  Use --l or --list-packages to list the allowable names."
+    emergency "set_or_print_default.sh: Package ${package_name:-} not recognized.  Use --l or --list-packages to list the allowable names."
  fi
 }

--- a/prerequisites/build-functions/set_or_print_downloader.sh
+++ b/prerequisites/build-functions/set_or_print_downloader.sh
@@ -4,11 +4,13 @@
 # shellcheck disable=SC2154
 set_or_print_downloader()
 {
-  # Verify requirements
-  [ ! -z "${arg_D}" ] && [ ! -z "${arg_p:-${arg_P:-${arg_U:-${arg_V}}}}" ] &&
-    emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
 
-  package_name="${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}}"
+  # Verify requirements
+  [ ! -z "${arg_D}" ] && [ ! -z "${arg_p:-${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}}" ] &&
+    emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
+
+  package_name="${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}}}"
+
   if [[ "${package_name}" == "ofp" ]]; then
     ${OPENCOARRAYS_SRC_DIR}/prerequisites/install-ofp.sh "${@}"
     exit 0
@@ -20,10 +22,12 @@ set_or_print_downloader()
     wget_or_curl=wget
     ftp_or_curl=ftp-url
   fi
-  if [[ "${package_name}" == "gcc" && "${version_to_build}" != "trunk" ]]; then
-    gcc_fetch="${ftp_or_curl}"
-  else
-    gcc_fetch="svn"
+  if [[ "${package_name}" == "gcc" ]]; then
+    if [[ -z "${arg_b:-${arg_B:-}}" ]]; then
+      gcc_fetch="${ftp_or_curl}"
+    else
+      gcc_fetch="svn"
+    fi
   fi
   # This is a bash 3 hack standing in for a bash 4 hash (bash 3 is the lowest common
   # denominator because, for licensing reasons, OS X only has bash 3 by default.)

--- a/prerequisites/build-functions/set_or_print_downloader.sh
+++ b/prerequisites/build-functions/set_or_print_downloader.sh
@@ -33,16 +33,16 @@ set_or_print_downloader()
   # denominator because, for licensing reasons, OS X only has bash 3 by default.)
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_fetch=(
-    "gcc:${gcc_fetch}"
-    "wget:${ftp_or_curl}"
-    "cmake:${wget_or_curl}"
-    "mpich:${wget_or_curl}"
-    "flex:${wget_or_curl}"
-    "bison:${ftp_or_curl}"
-    "pkg-config:${wget_or_curl}"
-    "make:${ftp_or_curl}"
-    "m4:${ftp_or_curl}"
-    "subversion:${wget_or_curl}"
+    "gcc:${gcc_fetch-}"
+    "wget:${ftp_or_curl-}"
+    "cmake:${wget_or_curl-}"
+    "mpich:${wget_or_curl-}"
+    "flex:${wget_or_curl-}"
+    "bison:${ftp_or_curl-}"
+    "pkg-config:${wget_or_curl-}"
+    "make:${ftp_or_curl-}"
+    "m4:${ftp_or_curl-}"
+    "subversion:${wget_or_curl-}"
   )
   for package in "${package_fetch[@]}" ; do
      KEY="${package%%:*}"

--- a/prerequisites/build-functions/set_or_print_url.sh
+++ b/prerequisites/build-functions/set_or_print_url.sh
@@ -4,25 +4,27 @@
 set_or_print_url()
 {
   # Verify requirements
-  [ ! -z "${arg_U}" ] && [ ! -z "${arg_D:-${arg_p:-${arg_P:-${arg_V}}}}" ] &&
-    emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
+  [ ! -z "${arg_U}" ] && [ ! -z "${arg_D:-${arg_p:-${arg_P:-${arg_V:-${arg_B}}}}}" ] &&
+    emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
 
   # Get package name from argument passed with  -p, -D, -P, -V, or -U
-  package_to_build="${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}}"
+  package_to_build="${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}}}"
 
   if [[ "${package_to_build}" == 'cmake' ]]; then
     major_minor="${version_to_build%.*}"
-  elif [[ "${package_to_build}" == "gcc" && "${version_to_build}" != "trunk" ]]; then
-    gcc_url_head="ftp.gnu.org:/gnu/gcc/gcc-${version_to_build}/"
-  else
-    gcc_url_head="svn://gcc.gnu.org/svn/gcc/"
+  elif [[ "${package_to_build}" == "gcc" ]]; then
+    if [[ -z "${arg_b:-${arg_B}}" ]]; then
+      gcc_url_head="ftp.gnu.org:/gnu/gcc/gcc-${version_to_build}/"
+    else
+      gcc_url_head="svn://gcc.gnu.org/svn/gcc/"
+    fi
   fi
   package_url_head=(
-    "gcc;${gcc_url_head:-}"
+    "gcc;${gcc_url_head-}"
     "wget;ftp.gnu.org:/gnu/wget/"
     "m4;ftp.gnu.org:/gnu/m4/"
     "pkg-config;http://pkgconfig.freedesktop.org/releases/"
-    "mpich;http://www.mpich.org/static/downloads/${version_to_build}/"
+    "mpich;http://www.mpich.org/static/downloads/${version_to_build-}/"
     "flex;http://sourceforge.net/projects/flex/files/"
     "make;ftp://ftp.gnu.org/gnu/make/"
     "bison;ftp.gnu.org:/gnu/bison/"
@@ -32,6 +34,8 @@ set_or_print_url()
   for package in "${package_url_head[@]}" ; do
      KEY="${package%%;*}"
      VALUE="${package##*;}"
+     info "KEY=${KEY}  VALUE=${VALUE}"
+     
      if [[ "${package_to_build}" == "${KEY}" ]]; then
        # We recognize the package name so we set the URL head:
        url_head="${VALUE}"
@@ -39,27 +43,25 @@ set_or_print_url()
      fi
   done
 
-  # Set differing tails for GCC trunk versus branches
+  # Set differing tails for GCC release downloads versus development branch checkouts
   if [[ "${package_to_build}" == 'gcc' ]]; then
     if [[ "${fetch}" == 'svn' ]]; then
-      gcc_tail="${version_to_build}"
-    elif [[ "${version_to_build}" == '--avail' || "${version_to_build}" == '-a' ]]; then
-      gcc_tail='branches'
+      gcc_tail=${version_to_build-branches}
     else
       gcc_tail="gcc-${version_to_build}.tar.bz2"
     fi
   fi
   package_url_tail=(
-    "gcc;${gcc_tail:-}"
-    "wget;wget-${version_to_build}.tar.gz"
-    "m4;m4-${version_to_build}.tar.bz2"
-    "pkg-config;pkg-config-${version_to_build}.tar.gz"
-    "mpich;mpich-${version_to_build}.tar.gz"
-    "flex;flex-${version_to_build}.tar.bz2"
-    "bison;bison-${version_to_build}.tar.gz"
-    "make;make-${version_to_build}.tar.bz2"
-    "cmake;cmake-${version_to_build}.tar.gz"
-    "subversion;subversion-${version_to_build}.tar.gz"
+    "gcc;${gcc_tail-}"
+    "wget;wget-${version_to_build-}.tar.gz"
+    "m4;m4-${version_to_build-}.tar.bz2"
+    "pkg-config;pkg-config-${version_to_build-}.tar.gz"
+    "mpich;mpich-${version_to_build-}.tar.gz"
+    "flex;flex-${version_to_build-}.tar.bz2"
+    "bison;bison-${version_to_build-}.tar.gz"
+    "make;make-${version_to_build-}.tar.bz2"
+    "cmake;cmake-${version_to_build-}.tar.gz"
+    "subversion;subversion-${version_to_build-}.tar.gz"
   )
   for package in "${package_url_tail[@]}" ; do
      KEY="${package%%;*}"

--- a/prerequisites/build.sh
+++ b/prerequisites/build.sh
@@ -63,12 +63,12 @@ export __flag_present=1
 # shellcheck disable=SC2154
 if [[ "${arg_l}" != "${__flag_present}" && "${arg_L}" != "${__flag_present}" &&
       "${arg_v}" != "${__flag_present}" && "${arg_h}" != "${__flag_present}" &&
-      -z "${arg_D:-${arg_p:-${arg_P:-${arg_U:-${arg_V}}}}}" ]]; then
-  help "${__base}: Insufficient arguments. Please pass either -D, -h, -l, -L, -p, -P, -U, -v, -V, or a longer equivalent."
+      -z "${arg_D:-${arg_p:-${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}}}" ]]; then
+  help "${__base}: Insufficient arguments. Please pass either -B, -D, -h, -l, -L, -p, -P, -U, -v, -V, or a longer equivalent."
 fi
 
-# Suppress info and debug messages if -l, -P, -U, -V, -D, or their longer equivalent is present:
-[[ "${arg_l}" == "${__flag_present}" || ! -z "${arg_P:-${arg_U:-${arg_V:-${arg_D}}}}" ]] && suppress_info_debug_messages
+# Suppress info and debug messages if -B, -l, -P, -U, -V, -D, or their longer equivalent is present:
+ [[ "${arg_l}" == "${__flag_present}" || ! -z "${arg_P:-${arg_U:-${arg_V:-${arg_D:-${arg_B}}}}}" ]] && suppress_info_debug_messages
 
 [ -z "${LOG_LEVEL:-}" ] && emergency "Cannot continue without LOG_LEVEL. "
 
@@ -90,6 +90,7 @@ info "__usage: ${__usage}"
 info "LOG_LEVEL: ${LOG_LEVEL}"
 
 info "-b (--branch):           ${arg_b} "
+info "-B (--list-branches):    ${arg_B} "
 info "-c (--with-c):           ${arg_c} "
 info "-C (--with-cxx):         ${arg_C} "
 info "-d (--debug):            ${arg_d} "
@@ -113,10 +114,12 @@ info "-v (--version):          ${arg_v} "
 info "-V (--print-version):    ${arg_V} "
 }
 
-# shellcheck source=./build-functions/set_or_print_default_version.sh
-source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_default_version.sh"
-set_or_print_default_version "${@}"
-export version_to_build="${arg_I:-${default_version}}"
+if [[ -z "${arg_B}" ]]; then
+  # shellcheck source=./build-functions/set_or_print_default_version.sh
+  source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_default_version.sh"
+  set_or_print_default_version "${@}"
+  export version_to_build="${arg_I:-${default_version}}"
+fi
 
 # shellcheck source=./build-functions/set_or_print_downloader.sh
 source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_downloader.sh"
@@ -128,20 +131,25 @@ set_or_print_url
 
 # shellcheck source=./build-functions/set_or_print_installation_path.sh
 source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_installation_path.sh"
-set_or_print_installation_path
+
+if [[ -z "${arg_B}" ]]; then
+  set_or_print_installation_path
+fi
 
 # shellcheck source=./build-functions/download_if_necessary.sh
 source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/download_if_necessary.sh"
 download_if_necessary
 
-# shellcheck source=./build-functions/unpack_if_necessary.sh
-source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/unpack_if_necessary.sh"
-unpack_if_necessary
-
-# shellcheck source=./build-functions/set_compilers.sh
-source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_compilers.sh"
-set_compilers
-
-# shellcheck source=./build-functions/build_and_install.sh
-source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/build_and_install.sh"
-build_and_install
+if [[ -z "${arg_B}" ]]; then
+  # shellcheck source=./build-functions/unpack_if_necessary.sh
+  source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/unpack_if_necessary.sh"
+  unpack_if_necessary
+  
+  # shellcheck source=./build-functions/set_compilers.sh
+  source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_compilers.sh"
+  set_compilers
+  
+  # shellcheck source=./build-functions/build_and_install.sh
+  source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/build_and_install.sh"
+  build_and_install
+fi

--- a/prerequisites/build.sh
+++ b/prerequisites/build.sh
@@ -46,8 +46,6 @@ fi
 # shellcheck source=./use-case/bootstrap.sh
 source "${B3B_USE_CASE}/bootstrap.sh" "$@"
 
-
-
 # Set up a function to call when receiving an EXIT signal to do some cleanup. Remove if
 # not needed. Other signals can be trapped too, like SIGINT and SIGTERM.
 function cleanup_before_exit () {
@@ -118,7 +116,7 @@ if [[ -z "${arg_B}" ]]; then
   # shellcheck source=./build-functions/set_or_print_default_version.sh
   source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_default_version.sh"
   set_or_print_default_version "${@}"
-  export version_to_build="${arg_I:-${default_version}}"
+  export version_to_build="${arg_I:-${arg_b:-${default_version}}}"
 fi
 
 # shellcheck source=./build-functions/set_or_print_downloader.sh

--- a/prerequisites/build.sh
+++ b/prerequisites/build.sh
@@ -59,8 +59,9 @@ trap cleanup_before_exit EXIT # The signal is specified here. Could be SIGINT, S
 export __flag_present=1
 
 # shellcheck disable=SC2154
-if [[ "${arg_l}" != "${__flag_present}" && "${arg_L}" != "${__flag_present}" &&
-      "${arg_v}" != "${__flag_present}" && "${arg_h}" != "${__flag_present}" &&
+if [[ "${arg_l}" != "${__flag_present}" && 
+      "${arg_v}" != "${__flag_present}" && 
+      "${arg_h}" != "${__flag_present}" &&
       -z "${arg_D:-${arg_p:-${arg_P:-${arg_U:-${arg_V:-${arg_B}}}}}}" ]]; then
   help "${__base}: Insufficient arguments. Please pass either -B, -D, -h, -l, -L, -p, -P, -U, -v, -V, or a longer equivalent."
 fi
@@ -100,7 +101,6 @@ info "-i (--install-prefix):   ${arg_i} "
 info "-j (--num-threads):      ${arg_j} "
 info "-I (--install-version):  ${arg_I} "
 info "-l (--list-packages):    ${arg_l} "
-info "-L (--list-branches):    ${arg_L} "
 info "-m (--with-cmake):       ${arg_m} "
 info "-M (--with-mpi):         ${arg_M} "
 info "-n (--no-color):         ${arg_n} "

--- a/prerequisites/build.sh-usage
+++ b/prerequisites/build.sh-usage
@@ -1,5 +1,5 @@
-  -b --branch [arg]           Install the specified repository development branch.
-  -B --list-branches [arg]    List the available branches in the specified package's repository. (currently only arg=gcc is supported)
+  -b --install-branch [arg]   Install the specified repository development branch.
+  -B --list-branches [arg]    List the available branches in the specified package's repository.
   -c --with-c [arg]           Use the specified C compiler. Default="gcc"
   -C --with-cxx [arg]         Use the specified C++ compiler. Default="g++"
   -d --debug                  Enable debug mode.
@@ -11,7 +11,6 @@
   -j --num-threads [arg]      Number of threads to use when invoking make. Default="1"
   -I --install-version [arg]  Package version to install. (To see default, use -V or --print-version)
   -l --list-packages          List the packages this script can install.
-  -L --list-branches          List the repository branches this script can download.
   -m --with-cmake [arg]       Use the specified CMake installation. Default="cmake"
   -M --with-mpi [arg]         Use the specified MPI installation. 
   -n --no-color               Disable color output.

--- a/prerequisites/build.sh-usage
+++ b/prerequisites/build.sh-usage
@@ -1,4 +1,5 @@
-  -b --branch [arg]           Repository branch to download. Default="trunk"
+  -b --branch [arg]           Install the specified repository development branch.
+  -B --list-branches [arg]    List the available branches in the specified package's repository. (currently only arg=gcc is supported)
   -c --with-c [arg]           Use the specified C compiler. Default="gcc"
   -C --with-cxx [arg]         Use the specified C++ compiler. Default="g++"
   -d --debug                  Enable debug mode.


### PR DESCRIPTION
The following now works to list the available gcc development branches:
```
./install.sh -B gcc
```
and the following will build, for example, the gcc trunk:
```
./install.sh -b trunk -p gcc -i /opt
```