### PR TITLE
Treat user-specified install prefix as full path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
     - MPICH_URL_HEAD="http://www.mpich.org/static/downloads/$MPICH_VER"
     - MPICH_URL_TAIL="mpich-${MPICH_VER}.tar.gz"
     - MPICH_DIR="$HOME/.local/usr/mpich"
-    - MPICH_BOT_URL_HEAD="https://github.com/sourceryinstitute/opencoarrays/files/303249/"
-    - MPICH_BOT_URL_TAIL="mpich-3.2_1.yosemite.bottle.1.tar.gz"
+    - MPICH_BOT_URL_HEAD="https://github.com/sourceryinstitute/opencoarrays/files/452136/"
+    - MPICH_BOT_URL_TAIL="mpich-3.2_2.yosemite.bottle.1.tar.gz"
 
 matrix:
   include:

--- a/install.sh
+++ b/install.sh
@@ -194,9 +194,6 @@ info  "-y (--yes-to-all):       ${arg_y}"
 this_script="$(basename "$0")"
 export this_script
 
-export install_path="${arg_i%/}"
-info "install_path=\"${install_path}\""
-
 export num_threads="${arg_j}"
 info "num_threads=\"${arg_j}\""
 

--- a/install.sh
+++ b/install.sh
@@ -194,6 +194,9 @@ info  "-y (--yes-to-all):       ${arg_y}"
 this_script="$(basename "$0")"
 export this_script
 
+export install_path="${arg_i%/}"
+info "install_path=\"${install_path}\""
+
 export num_threads="${arg_j}"
 info "num_threads=\"${arg_j}\""
 

--- a/install.sh-usage
+++ b/install.sh-usage
@@ -7,7 +7,7 @@
   -e --verbose                Enable verbose mode, print script as it is executed.
   -f --with-fortran [arg]     Use specified Fortran compiler. 
   -h --help                   Print this page.
-  -i --install-prefix [arg]   Install package in specified path. Default="${OPENCOARRAYS_SRC_DIR}/prerequisites/installations/"
+  -i --install-prefix [arg]   Install package in specified path. Default="${OPENCOARRAYS_SRC_DIR}/prerequisites/installations/${package_name:-}/${version_to_build:-}"
   -I --install-version [arg]  Install package version.
   -j --num-threads [arg]      Number of threads to use when invoking make. Default="1"
   -l --list-packages          Print packages this script can install.

--- a/prerequisites/build-functions/set_or_print_installation_path.sh
+++ b/prerequisites/build-functions/set_or_print_installation_path.sh
@@ -7,7 +7,12 @@ set_or_print_installation_path()
   [ ! -z "${arg_P}" ] && [ ! -z "${arg_p:-${arg_D:-${arg_U:-${arg_V}}}}" ] &&
     emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
 
-  install_path="${arg_i%/}/${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}}/${version_to_build}"
+  arg_i_default="${OPENCOARRAYS_SRC_DIR}/prerequisites/installations/"
+  if [[ "${arg_i:-}" ==  "${arg_i_default}" ]]; then
+    install_path="${arg_i%/}/${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}}/${version_to_build}"
+  else
+    install_path="${arg_i%/}"
+  fi
 
   # If -P is present, print ${install_path} and exit with normal status
   if [[ ! -z "${arg_P:-}" ]]; then

--- a/prerequisites/build.sh
+++ b/prerequisites/build.sh
@@ -124,7 +124,7 @@ fi
 # shellcheck source=./build-functions/set_or_print_downloader.sh
 source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_downloader.sh"
 # shellcheck disable=SC2119
-set_or_print_downloader
+set_or_print_downloader $@
 
 # shellcheck source=./build-functions/set_or_print_url.sh
 source "${OPENCOARRAYS_SRC_DIR:-}/prerequisites/build-functions/set_or_print_url.sh"


### PR DESCRIPTION
previously subdirectories named after the package and version were
appended to user-specified install prefixes so

./install.sh -p gcc -i /opt -I 6.1.0

would produce an installation directory named "/opt/gcc/6.1.0".
This differs from how most packages interpret the install prefix
and can result in redundancy if the user has already included such
information in the -i argument. With this commmit, the bare user-
-specified install prefix will be used with nothing appended.  If
no -i argument is present, the default still contains the package
name and version: ${OPENCOARRAYS_SRC_DIR}/prerequisites/installations/gcc/6.1.0)