### PR TITLE
Fix for sync images issue and some cleanup (#222)

### DIFF
--- a/install.sh-usage
+++ b/install.sh-usage
@@ -1,4 +1,4 @@
-  -b --install-branch [arg]           Install the specified repository development branch.
+  -b --install-branch [arg]   Install the specified repository development branch.
   -B --list-branches [arg]    List the available branches in the specified package's repository.
   -c --with-c [arg]           Use specified C compiler. 
   -C --with-cxx [arg]         Use specified C++ compiler. 

--- a/prerequisites/acceptable_compiler.f90
+++ b/prerequisites/acceptable_compiler.f90
@@ -35,5 +35,5 @@
 program main
   use iso_fortran_env, only : compiler_version
   implicit none
-  print *,compiler_version() >= "GCC version 6.1.0 "
+  print *,(compiler_version() >= "GCC version 6.1.0 ") .and. (compiler_version() < "GCC version 7.0.0 ")
 end program

--- a/prerequisites/install-functions/find_or_install.sh
+++ b/prerequisites/install-functions/find_or_install.sh
@@ -163,7 +163,7 @@ find_or_install()
 
         else
 
-          echo -e "$this_script: Checking whether $executable in PATH wraps gfortran version $(./build.sh -V gcc) or later... "
+          echo -e "$this_script: Checking whether $executable in PATH wraps gfortran version >= $(./build.sh -V gcc) and < 7.0.0 ... "
           $executable acceptable_compiler.f90 -o acceptable_compiler
           $executable print_true.f90 -o print_true
           acceptable=$(./acceptable_compiler)

--- a/src/libcaf.h
+++ b/src/libcaf.h
@@ -43,6 +43,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #define unlikely(x)     __builtin_expect(!!(x), 0)
 #endif
 
+#if __GNUC__ >= 7
+#define GCC_GE_7 1
+#endif
+
 #ifdef PREFIX_NAME
 #define PREFIX3(X,Y) X ## Y
 #define PREFIX2(X,Y) PREFIX3(X,Y)
@@ -101,6 +105,87 @@ typedef struct caf_vector_t {
 caf_vector_t;
 
 
+#ifdef GCC_GE_7
+/* Keep in sync with gcc/libgfortran/caf/libcaf.h.  */
+typedef enum caf_ref_type_t {
+  /* Reference a component of a derived type, either regular one or an
+     allocatable or pointer type.  For regular ones idx in caf_reference_t is
+     set to -1.  */
+  CAF_REF_COMPONENT,
+  /* Reference an allocatable array.  */
+  CAF_REF_ARRAY,
+  /* Reference a non-allocatable/non-pointer array.  */
+  CAF_REF_STATIC_ARRAY
+} caf_ref_type_t;
+
+/* Keep in sync with gcc/libgfortran/caf/libcaf.h.  */
+typedef enum caf_array_ref_t {
+  /* No array ref.  This terminates the array ref.  */
+  CAF_ARR_REF_NONE = 0,
+  /* Reference array elements given by a vector.  Only for this mode
+     caf_reference_t.u.a.dim[i].v is valid.  */
+  CAF_ARR_REF_VECTOR,
+  /* A full array ref (:).  */
+  CAF_ARR_REF_FULL,
+  /* Reference a range on elements given by start, end and stride.  */
+  CAF_ARR_REF_RANGE,
+  /* Only a single item is referenced given in the start member.  */
+  CAF_ARR_REF_SINGLE,
+  /* An array ref of the kind (i:), where i is an arbitrary valid index in the
+     array.  The index i is given in the start member.  */
+  CAF_ARR_REF_OPEN_END,
+  /* An array ref of the kind (:i), where the lower bound of the array ref
+     is given by the remote side.  The index i is given in the end member.  */
+  CAF_ARR_REF_OPEN_START
+} caf_array_ref_t;
+
+/* References to remote components of a derived type.
+   Keep in sync with gcc/libgfortran/caf/libcaf.h.  */
+typedef struct caf_reference_t {
+  /* A pointer to the next ref or NULL.  */
+  struct caf_reference_t *next;
+  /* The type of the reference.  */
+  /* caf_ref_type_t, replaced by int to allow specification in fortran FE.  */
+  int type;
+  /* The size of an item referenced in bytes.  I.e. in an array ref this is
+     the factor to advance the array pointer with to get to the next item.
+     For component refs this gives just the size of the element referenced.  */
+  size_t item_size;
+  union {
+    struct {
+      /* The offset (in bytes) of the component in the derived type.  */
+      ptrdiff_t offset;
+      /* The offset (in bytes) to the caf_token associated with this
+	 component.  NULL, when not allocatable/pointer ref.  */
+      ptrdiff_t caf_token_offset;
+    } c;
+    struct {
+      /* The mode of the array ref.  See CAF_ARR_REF_*.  */
+      /* caf_array_ref_t, replaced by unsigend char to allow specification in
+	 fortran FE.  */
+      unsigned char mode[GFC_MAX_DIMENSIONS];
+      /* The type of a static array.  Unset for array's with descriptors.  */
+      int static_array_type;
+      /* Subscript refs (s) or vector refs (v).  */
+      union {
+	struct {
+	  /* The start and end boundary of the ref and the stride.  */
+	  ptrdiff_t start, end, stride;
+	} s;
+	struct {
+	  /* nvec entries of kind giving the elements to reference.  */
+	  void *vector;
+	  /* The number of entries in vector.  */
+	  size_t nvec;
+	  /* The integer kind used for the elements in vector.  */
+	  int kind;
+	} v;
+      } dim[GFC_MAX_DIMENSIONS];
+    } a;
+  } u;
+} caf_reference_t;
+#endif
+
 
 /* Common auxiliary functions: caf_auxiliary.c.  */
 
@@ -115,18 +200,38 @@ void PREFIX (finalize) (void);
 int PREFIX (this_image) (int);
 int PREFIX (num_images) (int, int);
 
-void *PREFIX (register) (size_t, caf_register_t, caf_token_t *, int *, char *,
-			int);
+#ifdef GCC_GE_7
+void PREFIX (register) (size_t, caf_register_t, caf_token_t *,
+						gfc_descriptor_t *, int *, char *, int);
+#else
+void * PREFIX (register) (size_t, caf_register_t, caf_token_t *,
+						  int *, char *, int);
+#endif
 void PREFIX (deregister) (caf_token_t *, int *, char *, int);
 
 void PREFIX (caf_get) (caf_token_t, size_t, int, gfc_descriptor_t *,
-		       caf_vector_t *, gfc_descriptor_t *, int, int);
+		       caf_vector_t *, gfc_descriptor_t *, int, int, int);
 void PREFIX (caf_send) (caf_token_t, size_t, int, gfc_descriptor_t *,
                         caf_vector_t *, gfc_descriptor_t *, int, int);
 
 void PREFIX (caf_sendget) (caf_token_t, size_t, int, gfc_descriptor_t *,
 			   caf_vector_t *, caf_token_t, size_t, int,
 			   gfc_descriptor_t *, caf_vector_t *, int, int);
+
+#ifdef GCC_GE_7
+void PREFIX(get_by_ref) (caf_token_t, int,
+							 gfc_descriptor_t *dst, caf_reference_t *refs,
+							 int dst_kind, int src_kind, bool may_require_tmp,
+							 bool dst_reallocatable, int *stat);
+void PREFIX(send_by_ref) (caf_token_t token, int image_index,
+							  gfc_descriptor_t *src, caf_reference_t *refs,
+							  int dst_kind, int src_kind, bool may_require_tmp,
+							  bool dst_reallocatable, int *stat);
+void PREFIX(sendget_by_ref) (caf_token_t dst_token, int dst_image_index,
+		caf_reference_t *dst_refs, caf_token_t src_token, int src_image_index,
+		caf_reference_t *src_refs, int dst_kind, int src_kind,
+		bool may_require_tmp, int *dst_stat, int *src_stat);
+#endif
 
 void PREFIX (co_max) (gfc_descriptor_t *, int, int *, char *, int, int);
 void PREFIX (co_min) (gfc_descriptor_t *, int, int *, char *, int, int);

--- a/src/tests/unit/send-get/get_with_offset_1d.f90
+++ b/src/tests/unit/send-get/get_with_offset_1d.f90
@@ -27,5 +27,5 @@ program get_offset_1d
     enddo
     write(*,*) 'Test passed.'
   endif
-
+sync all
 end program


### PR DESCRIPTION
* Fixes to support gcc-7's caf-interface.

* Added preproccessor guards.

* First steps to implemeting full featured caf_get_by_ref().
WARNING! Errorneous at the moment.

* Reverted change for burgers test in CMakeLists.txt.
Fixed most issues. One still needs a patch to gfortran. Therefore
the pde-solver might fail with an unpatched gfortran still.

* Removed define sticking to gcc-7.

* Fixed typo.

* Send-get/get_with_offset_1d.f90: Needs sync all at the end of the main program
	or the scope where array descriptors are stored may be already
	destroyed when accessed by other (slower) images.
mpi_caf.c: Fixing sync_images, when a stopped image is slow to reach its
	caf_finalize and set the stopped status, while other images have read an
	ok status already and now wait on its send. Realized by using waitany
	and propagating a stopped image status.
	Small speed up in get_by_ref and smaller memory footprint.

Still failing tests:
hello_multiverse: This test fails in general with the gcc-7 fortran compiler,
	because the string is not composed correctly. This is independent
	of coarrays being present or not.