### PR TITLE
Expose caf_init and caf_finalize in module to allow use with f2py, see #204

### DIFF
--- a/src/extensions/opencoarrays.F90
+++ b/src/extensions/opencoarrays.F90
@@ -51,6 +51,10 @@ module opencoarrays
     integer(atomic_int_kind), allocatable :: atom[:]
   end type
 #endif
+#ifdef EXPOSE_INIT_FINALIZE
+  public :: caf_init
+  public :: caf_finalize
+#endif
 
   ! Generic interface to co_broadcast with implementations for various types, kinds, and ranks
   interface co_reduce
@@ -195,6 +199,29 @@ module opencoarrays
 
   ! Bindings for OpenCoarrays C procedures
   interface
+
+    ! C function signature from ../mpi/mpi_caf.c:
+    ! void
+    ! PREFIX (init) (int *argc, char ***argv)
+#ifdef COMPILER_SUPPORTS_CAF_INTRINSICS
+    subroutine caf_init(argc,argv) bind(C,name="_caf_extensions_init")
+#else
+    subroutine caf_init(argc,argv) bind(C,name="_gfortran_caf_init")
+#endif
+      import :: c_int,c_ptr
+      type(c_ptr), value :: argc
+      type(c_ptr), value :: argv
+    end subroutine
+
+    ! C function signature from ../mpi/mpi_caf.c:
+    ! void
+    ! PREFIX (finalize) (void)
+#ifdef COMPILER_SUPPORTS_CAF_INTRINSICS
+    subroutine caf_finalize() bind(C,name="_caf_extensions_finalize")
+#else
+    subroutine caf_finalize() bind(C,name="_gfortran_caf_finalize")
+#endif
+    end subroutine
 
     ! C function signature from ../mpi/mpi_caf.c:
     ! void

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -15,6 +15,11 @@ if(gfortran_compiler AND (NOT opencoarrays_aware_compiler))
   add_definitions(-DCOMPILER_SUPPORTS_CAF_INTRINSICS)
 endif()
 
+option(CAF_EXPOSE_INIT_FINALIZE "Expose caf_init and caf_finalize in opencoarrays module" FALSE)
+if(CAF_EXPOSE_INIT_FINALIZE)
+  add_definitions(-DEXPOSE_INIT_FINALIZE)
+endif()
+
 add_library(caf_mpi mpi_caf.c ../common/caf_auxiliary.c ../extensions/opencoarrays.F90)
 
 set_target_properties ( caf_mpi


### PR DESCRIPTION
 Fixes #204

 At configure time, choose whether to expose the `caf_init` and
 `caf_finalize` functions in the opencoarrays (extension) module by using `-DCAF_EXPOSE_INIT_FINALIZE`.

N.B. the semantics of using C pointers with Fortran still mystifies me a bit, and I don't really understand what the point of passing `argc` and `argv` to `MPI_init` is (since I always use fortran, where the only arg is `ierr`). So for my interface to `caf_init` which takes `argc` and `argv` as arguments, I have declared both as `type(c_ptr)` so it is the users responsibility to pass the appropriate `c_ptr` in to them. In my testing I just passed `c_null_ptr`s and it seemed to work fine. Also, please note, that the `caf` compiler wrapper script does not pass in the installed module file for open coarrays aware (OCA) compilers (GCC/GFortran) to the compiler, so you'll have to add something like `-J/usr/local/mod` or whatever to the `caf` script if you use it and want the compiler to find your installed module file and compile time.

@amckinstry: will this suit your needs? Please take a look and let me know if you need any changes.