### PR TITLE
Better cmake mpi passing #39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
     - MPICH_DIR="$HOME/.local/usr/mpich"
     - MPICH_BOT_URL_HEAD="https://github.com/sourceryinstitute/opencoarrays/files/452136/"
     - MPICH_BOT_URL_TAIL="mpich-3.2_2.yosemite.bottle.1.tar.gz"
+    - FC=gfortran-6
+    - CC=gcc-6
+    - CXX=g++-6
 
 matrix:
   include:
@@ -84,9 +87,6 @@ before_install:
       [[ -d "$CACHE/bin" ]] || mkdir -p "$CACHE/bin"
       [[ -d "$MPICH_DIR" ]] || mkdir -p "$MPICH_DIR"
       export PATH="$CACHE/bin:$PATH"
-      export FC=gfortran-6
-      export CC=gcc-6
-      export CXX=g++-6
       $FC --version
       $CC --version
       $CXX --version
@@ -103,8 +103,6 @@ install:
         [[ "$(brew ls --versions $pkg)" ]] || brew install --force-bottle $pkg
         brew outdated $pkg || brew upgrade --force-bottle $pkg
       done
-      export FC=gfortran-6
-      export CC=gcc-6
       if ! [[ "$(brew ls --versions mpich)" ]] && [[ "X$BUILD_TYPE" != "XInstallScript" ]]; then
         wget ${MPICH_BOT_URL_HEAD}${MPICH_BOT_URL_TAIL}
         brew install --force-bottle ${MPICH_BOT_URL_TAIL}
@@ -114,8 +112,6 @@ install:
         mpif90 --version
         mpicc --version
         cmake --version
-        export FC=mpif90
-        export CC=mpicc
       elif [[ "X$BUILD_TYPE" = "XInstallScript" ]]; then # uninstall some stuff if present
         [[ "$(brew ls --versions cmake)" ]] && brew rm cmake || true
         [[ "$(brew ls --versions mpich)" ]] && brew rm mpich || true
@@ -143,8 +139,6 @@ install:
       mpif90 --version
       mpicc --version
       cmake --version
-      export FC=mpif90
-      export CC=mpicc
     fi
     set +o errexit
 
@@ -152,8 +146,6 @@ script:
   - |
     set -o errexit
     if [[ "X$BUILD_TYPE" = "XInstallScript" ]]; then
-      export FC=gfortran-6
-      export CC=gcc-6
       [[ -d "$HOME/opt" ]] || mkdir "$HOME/opt"
       [[ -d "$HOME/bin" ]] || mkdir "$HOME/bin"
       ln -fs "$(which gfortran-6)" "$HOME/bin/gfortran"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,21 @@ if(gfortran_compiler)
   unset(CMAKE_REQUIRED_FLAGS)
 endif()
 
+
+#----------------------------------------------------------------------------
+# Find MPI and set some flags so that FC and CC can point to gfortran and gcc
+#----------------------------------------------------------------------------
+find_package(MPI REQUIRED)
+
+set(CMAKE_C_COMPILE_FLAGS ${CMAKE_C_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS})
+set(CMAKE_C_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} ${MPI_C_LINK_FLAGS})
+set(CMAKE_Fortran_COMPILE_FLAGS ${CMAKE_Fortran_COMPILE_FLAGS} ${MPI_Fortran_COMPILE_FLAGS})
+set(CMAKE_Fortran_LINK_FLAGS ${CMAKE_Fortran_LINK_FLAGS} ${MPI_Fortran_LINK_FLAGS})
+include_directories(BEFORE ${MPI_C_INCLUDE_PATH} ${MPI_Fortran_INCLUDE_PATH})
+
+#-------------------------------
+# Recurse into the src directory
+#-------------------------------
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_subdirectory(src)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
-find_package(MPI REQUIRED)
+if (NOT MPI_C_FOUND)
+  find_package(MPI REQUIRED)
+
+  set(CMAKE_C_COMPILE_FLAGS ${CMAKE_C_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS})
+  set(CMAKE_C_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} ${MPI_C_LINK_FLAGS})
+  set(CMAKE_Fortran_COMPILE_FLAGS ${CMAKE_Fortran_COMPILE_FLAGS} ${MPI_Fortran_COMPILE_FLAGS})
+  set(CMAKE_Fortran_LINK_FLAGS ${CMAKE_Fortran_LINK_FLAGS} ${MPI_Fortran_LINK_FLAGS})
+  include_directories(BEFORE ${MPI_C_INCLUDE_PATH} ${MPI_Fortran_INCLUDE_PATH})
+endif()
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
   set(gfortran_compiler true)
@@ -21,6 +29,7 @@ if(CAF_EXPOSE_INIT_FINALIZE)
 endif()
 
 add_library(caf_mpi mpi_caf.c ../common/caf_auxiliary.c ../extensions/opencoarrays.F90)
+target_link_libraries(caf_mpi PRIVATE ${MPI_C_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 set_target_properties ( caf_mpi
   PROPERTIES
@@ -29,7 +38,6 @@ set_target_properties ( caf_mpi
   )
 
 
-target_include_directories(caf_mpi PRIVATE ${MPI_C_INCLUDE_PATH})
 if (gfortran_compiler)
   target_compile_options(caf_mpi INTERFACE -fcoarray=lib)
 endif()
@@ -90,8 +98,5 @@ file(APPEND "${caf_launcher}"  "caf_version=${PROJECT_VERSION}\n")
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../extensions/cafrun-foot FOOTER)
 file(APPEND "${caf_launcher}" "${FOOTER}")
-
-# This could be needed to produce shared libraries:
-#target_link_libraries(caf_mpi PRIVATE ${MPI_C_LIBRARIES})
 
 #set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${exe_dir}/cafrun;${exe_dir}/caf;${exe_dir}/test-caf-tally.sh")


### PR DESCRIPTION
This (#39), along with #79 are blocking #22.

Now through the magic of `find_package(MPI)` one need not pass in the MPI compiler wrapper to CC and FC, but simply passing FC=gfortran, CC=gcc-6 should do the trick.