### PR TITLE
Fix mpi search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,9 @@ script:
       ln -fs "$(which g++-6)" "$HOME/bin/g++"
       export PATH="$PATH:$HOME/bin"
       ./install.sh --yes-to-all -i "$HOME/opt/opencoarrays" -j 4 -f "$HOME/bin/gfortran" -c "$HOME/bin/gcc" -C "$HOME/bin/g++"
+      cd prerequisites/builds/opencoarrays*
+      ctest --output-on-failure
+      cd -
     else
       mkdir cmake-build
       cd cmake-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,8 +153,8 @@ script:
       ln -fs "$(which g++-6)" "$HOME/bin/g++"
       export PATH="$PATH:$HOME/bin"
       ./install.sh --yes-to-all -i "$HOME/opt/opencoarrays" -j 4 -f "$HOME/bin/gfortran" -c "$HOME/bin/gcc" -C "$HOME/bin/g++"
-      cd prerequisites/builds/opencoarrays*
-      ctest --output-on-failure
+      cd prerequisites/builds/opencoarrays/*
+      ../../../installations/cmake/*/bin/ctest --output-on-failure
       cd -
     else
       mkdir cmake-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,18 @@ endif()
 #----------------------------------------------------------------------------
 # Find MPI and set some flags so that FC and CC can point to gfortran and gcc
 #----------------------------------------------------------------------------
-find_package(MPI REQUIRED)
+
+# If the user passes FC=mpif90 etc. check and prefer that location
+get_filename_component( FTN_MPI_DIR "${CMAKE_Fortran_COMPILER}"
+  REALPATH )
+get_filename_component( C_MPI_DIR "${CMAKE_C_COMPILER}"
+  REALPATH )
+set ( MPI_HOME "${MPI_HOME}" "${FTN_MPI_DIR}/.." "${C_MPI_DIR}/.." )
+
+# Check the install.sh defaut mpich installation directories
+set ( MPI_HOME "${MPI_HOME}" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/3.1.4" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" )
+
+find_package( MPI REQUIRED )
 
 set(CMAKE_C_COMPILE_FLAGS ${CMAKE_C_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS})
 set(CMAKE_C_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} ${MPI_C_LINK_FLAGS})


### PR DESCRIPTION
Addresses issue reported by @rouson [here](https://github.com/sourceryinstitute/opencoarrays/pull/253#issuecomment-262607188) and makes it so that CMake can find MPI installation from `install.sh` even when it's not on the user's `PATH`