### PR TITLE
More robust MPI handling/finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ else()
 endif()
 
 if(gfortran_compiler)
+  set(OLD_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
   set(CMAKE_REQUIRED_FLAGS "-fcoarray=single -ffree-form")
 endif()
 include(CheckFortranSourceCompiles)
@@ -99,7 +100,8 @@ CHECK_Fortran_SOURCE_COMPILES("
   end program
 " Check_Simple_Coarray_Fortran_Source_Compiles)
 if(gfortran_compiler)
-  unset(CMAKE_REQUIRED_FLAGS)
+  set (CMAKE_REQUIRED_FLAGS ${OLD_REQUIRED_FLAGS})
+  unset(OLD_REQUIRED_FLAGS)
 endif()
 
 
@@ -108,17 +110,37 @@ endif()
 #----------------------------------------------------------------------------
 
 # If the user passes FC=mpif90 etc. check and prefer that location
-get_filename_component( FTN_MPI_DIR "${CMAKE_Fortran_COMPILER}"
+get_filename_component( FTN_COMPILER_NAME "${CMAKE_Fortran_COMPILER}"
+  NAME )
+get_filename_component( C_COMPILER_NAME "${CMAKE_C_COMPILER}"
+  NAME )
+get_filename_component( FTN_COMPILER_DIR "${CMAKE_Fortran_COMPILER}"
   REALPATH )
-get_filename_component( C_MPI_DIR "${CMAKE_C_COMPILER}"
+get_filename_component( C_COMPILER_DIR "${CMAKE_C_COMPILER}"
   REALPATH )
-set ( MPI_HOME "${MPI_HOME}" "${FTN_MPI_DIR}/.." "${C_MPI_DIR}/.." )
 
-# Check the install.sh defaut mpich installation directories
-set ( MPI_HOME "${MPI_HOME}" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/3.1.4" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" )
+if (FTN_COMPILER_NAME MATCHES '^[mM][pP][iI]')
+  set (MPI_Fortran_COMPILER "${CMAKE_Fortran_COMPILER}")
+endif()
+if (C_COMPILER_NAME MATCHES '^[mM][pP][iI]')
+  set (MPI_C_COMPILER "${CMAKE_C_COMPILER}")
+endif()
 
-find_package( MPI REQUIRED )
+find_package( MPI )
 
+if ( (NOT MPI_C_FOUND) OR (NOT MPI_Fortran_FOUND) )
+  find_program (MY_MPI_EXEC NAMES mpirun mpiexec lamexec srun
+    PATHS "${CMAKE_SOURCE_DIR/prerequisites/installations/mpich/3.1.4}" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" ENV PATH
+    HINTS "${FTN_COMPILER_DIR}" "${C_COMPILER_DIR}"
+    PATH_SUFFIXES bin)
+  set ( MPI_HOME "${MPI_HOME}" "${MY_MPI_EXEC}" "${MY_MPI_EXEC}/.." )
+  find_package( MPI REQUIRED )
+endif()
+
+
+#----------------
+# Setup MPI flags
+#----------------
 set(CMAKE_C_COMPILE_FLAGS ${CMAKE_C_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS})
 set(CMAKE_C_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} ${MPI_C_LINK_FLAGS})
 set(CMAKE_Fortran_COMPILE_FLAGS ${CMAKE_Fortran_COMPILE_FLAGS} ${MPI_Fortran_COMPILE_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,128 @@ if ( (NOT MPI_C_FOUND) OR (NOT MPI_Fortran_FOUND) )
   find_package( MPI REQUIRED )
 endif()
 
+#--------------------------------------------------------
+# Make sure a simple "hello world" C mpi program compiles
+#--------------------------------------------------------
+set(OLD_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS ${MPI_C_COMPILE_FLAGS} ${MPI_C_LINK_FLAGS})
+set(OLD_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_INCLUDES ${MPI_C_INCLUDE_PATH})
+set(OLD_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${MPI_C_LIBRARIES})
+include (CheckCSourceCompiles)
+CHECK_C_SOURCE_COMPILES("
+#include <mpi.h>
+#include <stdio.h>
+int main(int argc, char** argv) {
+  MPI_Init(NULL, NULL);
+  int world_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  int world_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  char processor_name[MPI_MAX_PROCESSOR_NAME];
+  int name_len;
+  MPI_Get_processor_name(processor_name, &name_len);
+  printf('Hello world from processor %s, rank %d out of %d processors',
+         processor_name, world_rank, world_size);
+  MPI_Finalize();
+}"
+MPI_C_COMPILES)
+set(CMAKE_REQUIRED_FLAGS ${OLD_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_INCLUDES ${OLD_INCLUDES})
+set(CMAKE_REQUIRED_LIBRARIES ${OLD_LIBRARIES})
+unset(OLD_REQUIRED_FLAGS)
+unset(OLD_INCLUDES)
+unset(OLD_LIBRARIES)
+
+if (NOT MPI_C_COMPILES)
+  message(FATAL_ERROR "MPI_C is missing!"
+    "Try setting MPI_C_COMPILER to the appropriate C compiler wrapper script and reconfigure."
+    "i.e., `cmake -DMPI_C_COMPILER=/path/to/mpicc ..` or set it by editing the cache using"
+    "cmake-gui or ccmake."
+    )
+endif()
+
+#--------------------------------------------------------------
+# Make sure a simple "hello world" Fortran mpi program compiles
+# Try using mpi.mod first then fall back on includ 'mpif.h'
+#--------------------------------------------------------------
+set(OLD_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS "-ffree-form" ${MPI_Fortran_COMPILE_FLAGS} ${MPI_Fortran_LINK_FLAGS})
+set(OLD_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_INCLUDES ${MPI_Fortran_INCLUDE_PATH})
+set(OLD_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${MPI_Fortran_LIBRARIES})
+include (CheckCSourceCompiles)
+CHECK_Fortran_SOURCE_COMPILES("
+program mpi_hello
+use mpi
+implicit none
+integer :: ierr, mpi_world_size, mpi_world_rank, res_len
+character*(MPI_MAX_PROCESSOR_NAME) :: proc
+call mpi_init(ierr)
+call mpi_comm_size(MPI_COMM_WORLD,mpi_world_size,ierr)
+call mpi_comm_rank(MPI_COMM_WORLD,mpi_world_rank,ierr)
+call mpi_get_processor_name(proc,res_len,ierr)
+write(*,*) 'Hello from processor ', trim(proc), ' rank ', mpi_world_rank, ' out of ', mpi_world_size, '.'
+call mpi_finalize(ierr)
+end program
+"
+MPI_Fortran_MODULE_COMPILES)
+set(CMAKE_REQUIRED_FLAGS ${OLD_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_INCLUDES ${OLD_INCLUDES})
+set(CMAKE_REQUIRED_LIBRARIES ${OLD_LIBRARIES})
+unset(OLD_REQUIRED_FLAGS)
+unset(OLD_INCLUDES)
+unset(OLD_LIBRARIES)
+
+#--------------------------------
+# If that failed try using mpif.h
+#--------------------------------
+set(OLD_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS "-ffree-form" ${MPI_Fortran_COMPILE_FLAGS} ${MPI_Fortran_LINK_FLAGS})
+set(OLD_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_INCLUDES ${MPI_Fortran_INCLUDE_PATH})
+set(OLD_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${MPI_Fortran_LIBRARIES})
+include (CheckCSourceCompiles)
+CHECK_Fortran_SOURCE_COMPILES("
+program mpi_hello
+implicit none
+include 'mpif.h'
+integer :: ierr, mpi_world_size, mpi_world_rank, res_len
+character*(MPI_MAX_PROCESSOR_NAME) :: proc
+call mpi_init(ierr)
+call mpi_comm_size(MPI_COMM_WORLD,mpi_world_size,ierr)
+call mpi_comm_rank(MPI_COMM_WORLD,mpi_world_rank,ierr)
+call mpi_get_processor_name(proc,res_len,ierr)
+write(*,*) 'Hello from processor ', trim(proc), ' rank ', mpi_world_rank, ' out of ', mpi_world_size, '.'
+call mpi_finalize(ierr)
+end program
+"
+  MPI_Fortran_INCLUDE_COMPILES)
+set(CMAKE_REQUIRED_FLAGS ${OLD_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_INCLUDES ${OLD_INCLUDES})
+set(CMAKE_REQUIRED_LIBRARIES ${OLD_LIBRARIES})
+unset(OLD_REQUIRED_FLAGS)
+unset(OLD_INCLUDES)
+unset(OLD_LIBRARIES)
+
+if ( (NOT MPI_Fortran_MODULE_COMPILES) AND (NOT MPI_Fortran_INCLUDE_COMPILES) )
+  message ( WARNING "It appears that the Fortran MPI compiler is not working."
+    "For OpenCoarrays Aware compilers, this may be irrelavent:"
+    "  The src/extensions/opencoarrays.F90 module will be disabled, but it is"
+    "  possible that the build will succeed, despite this fishy circumstance."
+    )
+endif()
+
+if ( NOT MPI_Fortran_MODULE_COMPILES )
+  message ( WARNING "It appears that MPI was built with a different Fortran compiler."
+    "It is possible that this may cause unpredictable behavior. The build will continue"
+    "using `mpif.h` BUT please report any suspicious behavior to the OpenCoarrays"
+    "developers."
+    )
+endif()
 
 #----------------
 # Setup MPI flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
     "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
     " == CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}"
     "\nThis archive does not support in-source builds:\n"
-    "You must now delete the CMakeCache.txt file and the CMakeFiles/ directory under"
+    "You must now delete the CMakeCache.txt file and the CMakeFiles/ directory under "
     "the 'src' source directory or you will not be able to configure correctly!"
     "\nYou must now run something like:\n"
     "  $ rm -r CMakeCache.txt CMakeFiles/"
@@ -172,9 +172,9 @@ unset(OLD_INCLUDES)
 unset(OLD_LIBRARIES)
 
 if (NOT MPI_C_COMPILES)
-  message(FATAL_ERROR "MPI_C is missing!"
-    "Try setting MPI_C_COMPILER to the appropriate C compiler wrapper script and reconfigure."
-    "i.e., `cmake -DMPI_C_COMPILER=/path/to/mpicc ..` or set it by editing the cache using"
+  message(FATAL_ERROR "MPI_C is missing! "
+    "Try setting MPI_C_COMPILER to the appropriate C compiler wrapper script and reconfigure. "
+    "i.e., `cmake -DMPI_C_COMPILER=/path/to/mpicc ..` or set it by editing the cache using "
     "cmake-gui or ccmake."
     )
 endif()
@@ -245,17 +245,17 @@ unset(OLD_INCLUDES)
 unset(OLD_LIBRARIES)
 
 if ( (NOT MPI_Fortran_MODULE_COMPILES) AND (NOT MPI_Fortran_INCLUDE_COMPILES) )
-  message ( WARNING "It appears that the Fortran MPI compiler is not working."
-    "For OpenCoarrays Aware compilers, this may be irrelavent:"
-    "  The src/extensions/opencoarrays.F90 module will be disabled, but it is"
+  message ( WARNING "It appears that the Fortran MPI compiler is not working. "
+    "For OpenCoarrays Aware compilers, this may be irrelavent: "
+    "  The src/extensions/opencoarrays.F90 module will be disabled, but it is "
     "  possible that the build will succeed, despite this fishy circumstance."
     )
 endif()
 
 if ( NOT MPI_Fortran_MODULE_COMPILES )
-  message ( WARNING "It appears that MPI was built with a different Fortran compiler."
-    "It is possible that this may cause unpredictable behavior. The build will continue"
-    "using `mpif.h` BUT please report any suspicious behavior to the OpenCoarrays"
+  message ( WARNING "It appears that MPI was built with a different Fortran compiler. "
+    "It is possible that this may cause unpredictable behavior. The build will continue "
+    "using `mpif.h` BUT please report any suspicious behavior to the OpenCoarrays "
     "developers."
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,9 @@ if ( (NOT MPI_Fortran_MODULE_COMPILES) AND (NOT MPI_Fortran_INCLUDE_COMPILES) )
     )
 endif()
 
-if ( NOT MPI_Fortran_MODULE_COMPILES )
+if ( MPI_Fortran_MODULE_COMPILES )
+  add_definitions(-DMPI_WORKING_MODULE)
+else()
   message ( WARNING "It appears that MPI was built with a different Fortran compiler. "
     "It is possible that this may cause unpredictable behavior. The build will continue "
     "using `mpif.h` BUT please report any suspicious behavior to the OpenCoarrays "

--- a/src/extensions/opencoarrays.F90
+++ b/src/extensions/opencoarrays.F90
@@ -33,7 +33,7 @@ module opencoarrays
   implicit none
 
 #ifndef MPI_WORKING_MODULE
-#include 'mpif.h'
+  include 'mpif.h'
 #endif
 
   private

--- a/src/extensions/opencoarrays.F90
+++ b/src/extensions/opencoarrays.F90
@@ -32,6 +32,10 @@ module opencoarrays
   use iso_c_binding, only : c_int,c_char,c_ptr,c_loc,c_double,c_int32_t,c_ptrdiff_t,c_sizeof,c_bool,c_funloc
   implicit none
 
+#ifndef MPI_WORKING_MODULE
+#include 'mpif.h'
+#endif
+
   private
   public :: co_reduce
   public :: co_broadcast
@@ -726,7 +730,9 @@ contains
 
   ! Return the image number (MPI rank + 1)
   function this_image()  result(image_num)
+#ifdef MPI_WORKING_MODULE
     use mpi, only : MPI_Comm_rank
+#endif
     integer(c_int) :: image_num,ierr
    !image_num = opencoarrays_this_image(unused)
     call MPI_Comm_rank(CAF_COMM_WORLD,image_num,ierr)
@@ -736,7 +742,9 @@ contains
 
   ! Return the total number of images
   function num_images()  result(num_images_)
+#ifdef MPI_WORKING_MODULE
     use mpi, only : MPI_Comm_size
+#endif
     integer(c_int) :: num_images_,ierr
    !num_images_ = opencoarrays_num_images(unused_coarray,unused_scalar)
     call MPI_Comm_size(CAF_COMM_WORLD,num_images_,ierr)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -34,18 +34,6 @@ endif()
 if (MPI_Fortran_MODULE_COMPILES)
   # likely the same compiler compiled MPI
   set(MPI_CAF_FORTRAN_FILES ../extensions/opencoarrays.F90)
-elseif(MPI_Fortran_INCLUDE_COMPILES)
-  # Likely a different version or completely different Fortran compiler built MPI
-  # Since the .mod file is incompatible hack together a replacement
-  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/my_mpi_mod.f90"
-    "
-    module mpi
-    implicit none
-    public
-    include 'mpif.h'
-    end module"
-    )
-  set(MPI_CAF_FORTRAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/my_mpi_mod.f90" ../extensions/opencoarrays.F90 )
 endif()
 
 add_library(caf_mpi mpi_caf.c ../common/caf_auxiliary.c ${MPI_CAF_FORTRAN_FILES})

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -28,7 +28,27 @@ if(CAF_EXPOSE_INIT_FINALIZE)
   add_definitions(-DEXPOSE_INIT_FINALIZE)
 endif()
 
-add_library(caf_mpi mpi_caf.c ../common/caf_auxiliary.c ../extensions/opencoarrays.F90)
+# Determine whether and how to include OpenCoarrays module based on if the Fortran MPI compiler:
+#   - workds
+#   - is compatible with the fortran compiler used to build the MPI implementation
+if (MPI_Fortran_MODULE_COMPILES)
+  # likely the same compiler compiled MPI
+  set(MPI_CAF_FORTRAN_FILES ../extensions/opencoarrays.F90)
+elseif(MPI_Fortran_INCLUDE_COMPILES)
+  # Likely a different version or completely different Fortran compiler built MPI
+  # Since the .mod file is incompatible hack together a replacement
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/my_mpi_mod.f90"
+    "
+    module mpi
+    implicit none
+    public
+    include 'mpif.h'
+    end module"
+    )
+  set(MPI_CAF_FORTRAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/my_mpi_mod.f90" ../extensions/opencoarrays.F90 )
+endif()
+
+add_library(caf_mpi mpi_caf.c ../common/caf_auxiliary.c ${MPI_CAF_FORTRAN_FILES})
 target_link_libraries(caf_mpi PRIVATE ${MPI_C_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 set_target_properties ( caf_mpi

--- a/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
+++ b/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
@@ -41,11 +41,6 @@ module run_size
 #  else
      implicit none
      include 'mpif.h'
-     interface WALLTIME
-       function MPI_WTIME() result(res)
-         double precision :: res
-       end function
-    end interface WALLTIME
 #  endif
 #else
   implicit none

--- a/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
+++ b/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
@@ -40,7 +40,7 @@ module run_size
      implicit none
 #  else
      implicit none
-#    include 'mpif.h'
+     include 'mpif.h'
      interface WALLTIME
        function MPI_WTIME() result(res)
          double precision :: res

--- a/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
+++ b/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
@@ -35,9 +35,21 @@
 module run_size
     use iso_fortran_env
 #ifndef HAVE_WALLTIME
-    use MPI, only : WALLTIME=>MPI_WTIME
+#  ifdef MPI_WORKING_MODULE
+     use MPI, only : WALLTIME=>MPI_WTIME
+     implicit none
+#  else
+     implicit none
+#    include 'mpif.h'
+     interface WALLTIME
+       function MPI_WTIME() result(res)
+         double precision :: res
+       end function
+    end interface WALLTIME
+#  endif
+#else
+  implicit none
 #endif
-    implicit none
         integer(int64), codimension[*] :: nx, ny, nz
         integer(int64), codimension[*] :: my, mx, first_y, last_y, first_x, last_x
         integer(int64) :: my_node, num_nodes

--- a/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
+++ b/src/tests/integration/dist_transpose/coarray_distributed_transpose.F90
@@ -41,6 +41,7 @@ module run_size
 #  else
      implicit none
      include 'mpif.h'
+#    define WALLTIME MPI_WTIME
 #  endif
 #else
   implicit none

--- a/src/tests/integration/pde_solvers/navier-stokes/coarray-shear_coll.F90
+++ b/src/tests/integration/pde_solvers/navier-stokes/coarray-shear_coll.F90
@@ -118,11 +118,7 @@ module run_size
 #  else
      implicit none
      include 'mpif.h'
-     interface WALLTIME
-       function MPI_WTIME() result(res)
-         double precision :: res
-       end function
-    end interface WALLTIME
+#    define WALLTIME MPI_WTIME
 #  endif
 #else
   implicit none

--- a/src/tests/integration/pde_solvers/navier-stokes/coarray-shear_coll.F90
+++ b/src/tests/integration/pde_solvers/navier-stokes/coarray-shear_coll.F90
@@ -112,9 +112,21 @@ module run_size
     use iso_fortran_env, only : int64,real64 ! 64-bit integer and real kind parameters
     use constants_module, only : one         ! 64-bit unit to ensure argument kind match
 #ifndef HAVE_WALLTIME
-    use MPI, only : WALLTIME=>MPI_WTIME
+#  ifdef MPI_WORKING_MODULE
+     use MPI, only : WALLTIME=>MPI_WTIME
+     implicit none
+#  else
+     implicit none
+#    include 'mpif.h'
+     interface WALLTIME
+       function MPI_WTIME() result(res)
+         double precision :: res
+       end function
+    end interface WALLTIME
+#  endif
+#else
+  implicit none
 #endif
-    implicit none
         real, codimension[*] ::  viscos, shear, b11, b22, b33, b12, velmax
         integer(int64), codimension[*] ::  nx, ny, nz, nsteps, output_step
         integer(int64), codimension[*] :: my, mx, first_y, last_y, first_x, last_x

--- a/src/tests/integration/pde_solvers/navier-stokes/coarray-shear_coll.F90
+++ b/src/tests/integration/pde_solvers/navier-stokes/coarray-shear_coll.F90
@@ -117,7 +117,7 @@ module run_size
      implicit none
 #  else
      implicit none
-#    include 'mpif.h'
+     include 'mpif.h'
      interface WALLTIME
        function MPI_WTIME() result(res)
          double precision :: res

--- a/src/tests/performance/BurgersMPI/shared.F90
+++ b/src/tests/performance/BurgersMPI/shared.F90
@@ -26,7 +26,11 @@
 
 module shared
   !module for sharing mpi functionality/variables with other modules/main
+#ifdef MPI_WORKING_MODULE
   use mpi !non-native mpi functionality
+#else
+# include 'mpif.h'
+#endif
   integer :: tag, status(MPI_STATUS_SIZE)
   integer :: MPI_COMM_CART
   integer :: my_id, num_procs, ierr, local_grid_resolution, left_id, right_id

--- a/src/tests/performance/BurgersMPI/shared.F90
+++ b/src/tests/performance/BurgersMPI/shared.F90
@@ -29,7 +29,7 @@ module shared
 #ifdef MPI_WORKING_MODULE
   use mpi !non-native mpi functionality
 #else
-# include 'mpif.h'
+  include 'mpif.h'
 #endif
   integer :: tag, status(MPI_STATUS_SIZE)
   integer :: MPI_COMM_CART

--- a/src/tests/performance/mpi_dist_transpose/mpi_distributed_transpose.F90
+++ b/src/tests/performance/mpi_dist_transpose/mpi_distributed_transpose.F90
@@ -38,9 +38,21 @@
 module mpi_run_size
     use iso_fortran_env
 #ifndef HAVE_WALLTIME
-    use MPI, only : WALLTIME=>MPI_WTIME
+#  ifdef MPI_WORKING_MODULE
+     use MPI, only : WALLTIME=>MPI_WTIME
+     implicit none
+#  else
+     implicit none
+#    include 'mpif.h'
+     interface WALLTIME
+       function MPI_WTIME() result(res)
+         double precision :: res
+       end function
+    end interface WALLTIME
+#  endif
+#else
+  implicit none
 #endif
-    implicit none
         integer(int64) :: nx, ny, nz
         integer(int64) :: my, mx, first_y, last_y, first_x, last_x
         integer(int64) :: my_node, num_nodes

--- a/src/tests/performance/mpi_dist_transpose/mpi_distributed_transpose.F90
+++ b/src/tests/performance/mpi_dist_transpose/mpi_distributed_transpose.F90
@@ -44,11 +44,7 @@ module mpi_run_size
 #  else
      implicit none
      include 'mpif.h'
-     interface WALLTIME
-       function MPI_WTIME() result(res)
-         double precision :: res
-       end function
-    end interface WALLTIME
+#    define WALLTIME MPI_WTIME
 #  endif
 #else
   implicit none

--- a/src/tests/performance/mpi_dist_transpose/mpi_distributed_transpose.F90
+++ b/src/tests/performance/mpi_dist_transpose/mpi_distributed_transpose.F90
@@ -43,7 +43,7 @@ module mpi_run_size
      implicit none
 #  else
      implicit none
-#    include 'mpif.h'
+     include 'mpif.h'
      interface WALLTIME
        function MPI_WTIME() result(res)
          double precision :: res

--- a/src/tests/unit/init_register/CMakeLists.txt
+++ b/src/tests/unit/init_register/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(initialize_mpi initialize_mpi.f90)
+add_executable(initialize_mpi initialize_mpi.F90)
 target_link_libraries(initialize_mpi OpenCoarrays)
 
 add_executable(register register.f90)

--- a/src/tests/unit/init_register/initialize_mpi.F90
+++ b/src/tests/unit/init_register/initialize_mpi.F90
@@ -31,7 +31,7 @@ program initialize_mpi
   implicit none
 #else
   implicit none
-# include 'mpif.h'
+  include 'mpif.h'
   interface
      subroutine MPI_COMM_SIZE(mpi_comm,nranks,ierr)
        integer, intent(in)  :: mpi_comm

--- a/src/tests/unit/init_register/initialize_mpi.F90
+++ b/src/tests/unit/init_register/initialize_mpi.F90
@@ -26,8 +26,19 @@
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 !
 program initialize_mpi
+#ifdef MPI_WORKING_MODULE
   use mpi, only : MPI_COMM_SIZE,MPI_COMM_WORLD
   implicit none
+#else
+  implicit none
+# include 'mpif.h'
+  interface
+     subroutine MPI_COMM_SIZE(mpi_comm,nranks,ierr)
+       integer, intent(in)  :: mpi_comm
+       integer, intent(out) :: nranks, ierr
+     end subroutine
+  end interface
+#endif
 
   ! Set invalid default image number and number of ranks
   integer :: me=-1,np=-1,ierr


### PR DESCRIPTION
 Untested, but this *should* behave better than the previous
 implementation and should try really hard to "do what you mean" ™️ 

I'll also try to address #246 as best we can... just do it through checking the .mod file compatibility... readelf is not something I want to deal with, and strings -a doesn't work because everyone uses strip before shipping binaries.

@jerryd mentioned that you might be able to unzip .mod files and get the GFortran version, but I haven't been able to do this, despite a few tries.