### PR TITLE
Edit caf/cafrun for FC=gfortran instead of mpif90

### DIFF
--- a/src/extensions/caf-foot
+++ b/src/extensions/caf-foot
@@ -63,7 +63,7 @@ fi
 # Default to "mpif90" Fortran compiler if environment variable CAFC is empty or unset:
 CAFC=${CAFC:-mpif90}
 
-# TODO -- improve the syntax of the "set" command below to accepted an unlimited number of arguments
+# TODO -- refactor this script to use the bash3boilerplate use case
 max_arguments=100
 link_args="-fcoarray=lib -lcaf_mpi"
 
@@ -77,8 +77,10 @@ if [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
     echo "BSD 3-Clause License.  For more information about these matters, see"
     echo "the file named LICENSE."
     echo ""
-elif [[ $1 == '-w' || $1 == '--wrapping' || $1 == '--wraps' ]]; then
+elif [[ $1 == '-w' || $1 == '--wraps' ]]; then
   echo "caf wraps CAFC=$CAFC"
+elif [[ $1 == '-s' || $1 == '--show' ]]; then
+  $CAFC -show
 elif [[ $1 == '-h' || $1 == '--help' ]]; then
   # Print usage information
   usage | less

--- a/src/extensions/cafrun-foot
+++ b/src/extensions/cafrun-foot
@@ -39,9 +39,9 @@ elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
   echo "the file named LICENSE."
   echo ""
 elif [[ $1 == '-w' || $1 == '--wraps' ]]; then
-  mpirun -v
+  "${CAFRUN}"-v
 elif [[ $1 == '-h' || $1 == '--help' ]]; then
   usage
 else
-  mpirun "$@"
+  "${CAFRUN}" "$@"
 fi

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -84,7 +84,7 @@ else()
 endif()
 
 if ( DEFINED ENV{FC} )
-  file(APPEND "${compiler_wrapper}"  "CAFC=$ENV{FC}\n")
+  file(APPEND "${compiler_wrapper}"  "CAFC=${MPI_Fortran_COMPILER}\n")
 endif ()
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
@@ -103,6 +103,7 @@ install(
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../extensions/cafrun-head CAFRUN_HEADER)
 file(WRITE  "${caf_launcher}" "${CAFRUN_HEADER}\n")
 file(APPEND "${caf_launcher}"  "caf_version=${PROJECT_VERSION}\n")
+file(APPEND "${caf_launcher}"  "CAFRUN=${MPIEXEC}\n")
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../extensions/cafrun-foot FOOTER)
 file(APPEND "${caf_launcher}" "${FOOTER}")


### PR DESCRIPTION
Before this commit, the `caf` was invoking gfortran directly because of the new practice of passing compilers instead of MPI wrappers in`FC=gfortran cmake ..` and `cafrun` was hardwired to invoke `mpif90`. With this commit, `caf` invokes `${MPI_Fortran_COMPILER}` and `cafrun` invokes `${MPIEXEC}`.