### PR TITLE
Add safer timeout for GCC 7 test and compact .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,18 +27,20 @@ matrix:
       env:
        - BUILD_TYPE="InstallScript"
          OSX_PACKAGES="gcc"
-    - os: linux
+    - &ubuntu
+      os: linux
       sudo: false
       env:
         - BUILD_TYPE="CodeCoverage"
       cache:
+        apt: false
         directories:
           - "$CACHE"
       addons:
         apt:
           sources:
-            - george-edison55-precise-backports
             - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
           packages:
             - gcc-6
             - gfortran-6
@@ -46,29 +48,15 @@ matrix:
             - binutils
             - cmake-data
             - cmake
-    - os: linux
-      sudo: false
+    -
+      <<: *ubuntu
       env:
         - BUILD_TYPE="Release"
-      cache:
-        directories:
-          - "$CACHE"
-      addons:
-        apt:
-          sources:
-            - george-edison55-precise-backports
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-            - gfortran-6
-            - g++-6
-            - binutils
-            - cmake-data
-            - cmake
-    - os: linux
-      sudo: false
+    -
+      <<: *ubuntu
       env:
         - BUILD_TYPE="InstallScript"
+      cache: false
       addons:
         apt:
           sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ if(opencoarrays_aware_compiler)
     add_mpi_test(async_comp_alloc 6 ${tests_root}/unit/init_register/async_comp_alloc)
     # Timeout async_comp_alloc test after 3 seconds to progess past the known failure
     set_property(TEST async_comp_alloc PROPERTY TIMEOUT_AFTER_MATCH 3 "known failure")
+    set_property(TEST async_comp_alloc PROPERTY TIMEOUT 6) # in the event old CMake is being used
   endif()
   add_mpi_test(get_array 2 ${tests_root}/unit/send-get/get_array)
   add_mpi_test(get_self 2 ${tests_root}/unit/send-get/get_self)


### PR DESCRIPTION
See discussion at #281 for details on the CTest timeout.

Attempting to decrease verbosity of the `matrix.include` element for `.travis.yml` using YAML anchors, references and merges.