### PR TITLE
Fix typo preventing cafrun --help from working

### DIFF
--- a/src/extensions/cafrun-foot
+++ b/src/extensions/cafrun-foot
@@ -1,4 +1,4 @@
-Usage()
+usage()
 {
     cmd=$(basename "$0")
     echo ""


### PR DESCRIPTION
Fixes small issue I accidentally introduced in https://github.com/sourceryinstitute/opencoarrays/commit/878e5b488cee1feb2186480717871c00e51a3a90 that causes `cafrun --help` to fail. Sorry!