### PR TITLE
Null array-descriptor in mpi-token causing segfault on finalize. (#293)

### DIFF
--- a/src/tests/integration/events/async-hello.F90
+++ b/src/tests/integration/events/async-hello.F90
@@ -69,11 +69,7 @@ program main
     end do
 
     sync all
-! Hardwire failure with GCC 7 (remove this preprocessor conditional after the silent failure with GCC 7 has been eliminated)
-#if __GNUC__ >= 7
-#else
     if (me==1) print *,"Test passed."
-#endif
 
   end associate
 

--- a/src/tests/regression/reported/issue-293-silent-event-failure.F90
+++ b/src/tests/regression/reported/issue-293-silent-event-failure.F90
@@ -41,10 +41,6 @@ program main
 
   if (num_images()<3) error stop "exposing issue 293 requires num_images()>=3"
   event post(test_post)
-! Hardwire failure with GCC 7 (remove this preprocessor conditional after the silent failure with GCC 7 has been eliminated)
-#if __GNUC__ >= 7
-#else
-    if (this_image()==1) print *,"Test passed."
-#endif
+  if (this_image()==1) print *,"Test passed."
 
 end program


### PR DESCRIPTION
This patch ensures that the array descriptor stored in the mpi-caf-token is
set to NULL consistently, when no real descriptor is stored in it.
Further does the patch ensure freeing memory with gcc-7.

The testcases have been actived again for annoucing their passing.

Reffing #293 