### PR TITLE
fix gfortran compiler detection (issue 305)

### DIFF
--- a/prerequisites/install-functions/find_or_install.sh
+++ b/prerequisites/install-functions/find_or_install.sh
@@ -266,7 +266,7 @@ find_or_install()
       info "$this_script: Checking whether $executable in PATH is version $(./build.sh -V gcc) or later..."
       $executable -o acceptable_compiler acceptable_compiler.f90 || true;
       $executable -o print_true print_true.f90 || true;
-      if [[ -f ./accepatable_compiler && -f ./print_true ]]; then
+      if [[ -f ./acceptable_compiler && -f ./print_true ]]; then
         is_true=$(./print_true)
         acceptable=$(./acceptable_compiler)
         rm acceptable_compiler print_true


### PR DESCRIPTION
There was a typo in the check for the compiled fortran binary that made the check fail every time.