### PR TITLE
Fix setting of C compiler var (issue 306)

### DIFF
--- a/prerequisites/install-functions/build_opencoarrays.sh
+++ b/prerequisites/install-functions/build_opencoarrays.sh
@@ -21,7 +21,7 @@ build_opencoarrays()
   # Set FC to the MPI implementation's gfortran command with any preceding path but without any subsequent arguments:
   FC="${MPIFC_show%%gfortran*}"gfortran
   # Set CC to the MPI implementation's gcc command...
-  CC="${MPICC_show%%gcc*}"gcc
+  CC="${MPICC_show%%gcc *}"gcc
   info "Configuring OpenCoarrays in ${PWD} with the command:"
   info "CC=\"${CC}\" FC=\"${FC}\" $CMAKE \"${opencoarrays_src_dir}\" -DCMAKE_INSTALL_PREFIX=\"${install_path}\" -DMPI_C_COMPILER=\"${MPICC}\" -DMPI_Fortran_COMPILER=\"${MPIFC}\""
   CC="${CC}" FC="${FC}" $CMAKE "${opencoarrays_src_dir}" -DCMAKE_INSTALL_PREFIX="${install_path}" -DMPI_C_COMPILER="${MPICC}" -DMPI_Fortran_COMPILER="${MPIFC}"


### PR DESCRIPTION
The wild card in the build script would eat the path component
of the installed gcc 6.1.0 build and set the var to a directory
instead of .../bin/gcc