### PR TITLE
Fix sync images to take the syncer's id from mpi_status.

### DIFF
--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -3098,7 +3098,7 @@ sync_images_internal (int count, int images[], int *stat, char *errmsg,
 	  if (i != MPI_UNDEFINED)
 	    {
 	      ++done_count;
-	      if (ierr == MPI_SUCCESS && arrived[i] == STAT_STOPPED_IMAGE)
+	      if (ierr == MPI_SUCCESS && arrived[s.MPI_SOURCE] == STAT_STOPPED_IMAGE)
 		{
 		  /* Possible future extension: Abort pending receives.  At the
 		     moment the receives are discarded by the program


### PR DESCRIPTION
Take the source index of the image that is sending the current image data from
the MPI_status handle of Waitany instead of the index i, which only denotes the
handle in the array of receive-requests.

Fixes #302 