### PR TITLE
Move "maintained?" badge to STATUS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 OpenCoarrays
 ============
 
-[![Maintenance](https://img.shields.io/maintenance/yes/2017.svg?style=flat-square)](https://github.com/sourceryinstitute/opencoarrays/commits/master)
 [![CI Build Status][build img]](https://travis-ci.org/sourceryinstitute/opencoarrays)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg?style=flat-square)](https://gitter.im/sourceryinstitute/opencoarrays)
 [![GitHub license][license img]](./LICENSE)

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,6 +7,7 @@
 OpenCoarrays Status
 ===================
 
+[![Maintenance](https://img.shields.io/maintenance/yes/2017.svg?style=flat-square)](https://github.com/sourceryinstitute/opencoarrays/commits/master)
 [![Download as PDF][pdf img]](http://md2pdf.herokuapp.com/sourceryinstitute/opencoarrays/blob/master/STATUS.pdf)
 
 Download this file as a PDF document


### PR DESCRIPTION
 But don't forget about it... in 2018 it will turn red without update
 [ci skip]