### PR TITLE
Ensure the correct MPIEXEC is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ the C compiler if it matches the Fortran compiler ID." )
   endif()
   set( CMAKE_Fortran_COMPILER_VERSION "${DETECTED_VER}" )
 endif()
-  
+
   # We have populated CMAKE_Fortran_COMPILER_VERSION if it was missing
   if(gfortran_compiler AND (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 5.0.0))
     set(opencoarrays_aware_compiler true)
@@ -155,13 +155,53 @@ endif()
 
 find_package( MPI )
 
-if ( (NOT MPI_C_FOUND) OR (NOT MPI_Fortran_FOUND) )
+if ( (NOT MPI_C_FOUND) OR (NOT MPI_Fortran_FOUND) OR (NOT MPIEXEC))
   find_program (MY_MPI_EXEC NAMES mpirun mpiexec lamexec srun
     PATHS "${CMAKE_SOURCE_DIR/prerequisites/installations/mpich/3.1.4}" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" ENV PATH
     HINTS "${FTN_COMPILER_DIR}" "${C_COMPILER_DIR}"
     PATH_SUFFIXES bin)
   set ( MPI_HOME "${MPI_HOME}" "${MY_MPI_EXEC}" "${MY_MPI_EXEC}/.." )
   find_package( MPI REQUIRED )
+endif()
+
+# Test for consistent MPI environment
+if (NOT MPIEXEC)
+  message ( ERROR "CMake failed to find `mpiexec` or similar. If building with `./install.sh` please
+report this bug to the OpenCoarrays developers at
+https://github.com/sourceryinstitute/opencoarrays/issues, otherwise use point CMake
+to the desired MPI runtime.")
+endif()
+
+get_filename_component(MPIEXEC_RELATIVE_LOC "${MPIEXEC}"
+  PROGRAM)
+get_filename_component(MPIEXEC_ABS_LOC "${MPIEXEC_RELATIVE_LOC}"
+  REALPATH)
+get_filename_component(MPIEXEC_DIR "${MPIEXEC_ABS_LOC}"
+  DIRECTORY)
+
+get_filename_component(MPICC_RELATIVE_LOC "${MPI_C_COMPILER}"
+  PROGRAM)
+get_filename_component(MPICC_ABS_LOC "${MPICC_RELATIVE_LOC}"
+  REALPATH)
+get_filename_component(MPICC_DIR "${MPICC_ABS_LOC}"
+  DIRECTORY)
+
+get_filename_component(MPIFC_RELATIVE_LOC "${MPI_Fortran_COMPILER}"
+  PROGRAM)
+get_filename_component(MPIFC_ABS_LOC "${MPIFC_RELATIVE_LOC}"
+  REALPATH)
+get_filename_component(MPIFC_DIR "${MPIFC_ABS_LOC}"
+  DIRECTORY)
+
+if ((MPIEXEC_DIR STREQUAL MPICC_DIR) AND (MPIEXEC_DIR STREQUAL MPIFC_DIR))
+  message ( STATUS "MPI runtime and compile time environments appear to be consistent")
+else()
+  message ( WARNING "MPIEXEC is in \"${MPIEXEC_DIR},\"
+which differs from the location of MPICC and/or MPIFC which are in
+\"${MPICC_DIR}\" and \"${MPIFC_DIR},\" respectively.
+This is likely indicative of a problem. If building with `./install.sh` please report
+this to the OpenCoarrays developers by filing a new issue at:
+https://github.com/sourceryinstitute/OpenCoarrays/issues/new")
 endif()
 
 #--------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.4)
 
 # Set the type/configuration of build to perform
 set ( CMAKE_CONFIGURATION_TYPES "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "CodeCoverage" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.2)
 
 # Set the type/configuration of build to perform
 set ( CMAKE_CONFIGURATION_TYPES "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "CodeCoverage" )

--- a/prerequisites/install-functions/build_opencoarrays.sh
+++ b/prerequisites/install-functions/build_opencoarrays.sh
@@ -22,9 +22,16 @@ build_opencoarrays()
   FC="${MPIFC_show[0]}"
   # Set CC to the MPI implementation's gcc command...
   CC="${MPICC_show[0]}"
+  # try to find mpiexec
+  MPIEXEC_CANDIDATES=($(find "${MPICC%/*}" -name 'mpiexec' -o -name 'mpirun'))
+  if ! ((${#MPIEXEC_CANDIDATES[@]} >= 1)); then
+    emergency "Could not find a suitable \`mpiexec\` in directory containing mpi wrappers (${MPICC%/*})"
+  else
+    MPIEXEC="${MPIEXEC_CANDIDATES[0]}"
+  fi
   info "Configuring OpenCoarrays in ${PWD} with the command:"
-  info "CC=\"${CC}\" FC=\"${FC}\" $CMAKE \"${opencoarrays_src_dir}\" -DCMAKE_INSTALL_PREFIX=\"${install_path}\" -DMPI_C_COMPILER=\"${MPICC}\" -DMPI_Fortran_COMPILER=\"${MPIFC}\""
-  CC="${CC}" FC="${FC}" $CMAKE "${opencoarrays_src_dir}" -DCMAKE_INSTALL_PREFIX="${install_path}" -DMPI_C_COMPILER="${MPICC}" -DMPI_Fortran_COMPILER="${MPIFC}"
+  info "CC=\"${CC}\" FC=\"${FC}\" $CMAKE \"${opencoarrays_src_dir}\" -DCMAKE_INSTALL_PREFIX=\"${install_path}\" -DMPIEXEC=\"${MPIEXEC}\" -DMPI_C_COMPILER=\"${MPICC}\" -DMPI_Fortran_COMPILER=\"${MPIFC}\""
+  CC="${CC}" FC="${FC}" $CMAKE "${opencoarrays_src_dir}" -DCMAKE_INSTALL_PREFIX="${install_path}" -DMPIEXEC="${MPIEXEC}" -DMPI_C_COMPILER="${MPICC}" -DMPI_Fortran_COMPILER="${MPIFC}"
   info "Building OpenCoarrays in ${PWD} with the command make -j${num_threads}"
   make "-j${num_threads}"
   if [[ ! -z ${SUDO:-} ]]; then
@@ -33,4 +40,3 @@ build_opencoarrays()
   info "Installing OpenCoarrays in ${install_path} with the command ${SUDO:-} make install"
   ${SUDO:-} make install
 }
-

--- a/prerequisites/install-functions/build_opencoarrays.sh
+++ b/prerequisites/install-functions/build_opencoarrays.sh
@@ -23,7 +23,7 @@ build_opencoarrays()
   # Set CC to the MPI implementation's gcc command...
   CC="${MPICC_show[0]}"
   # try to find mpiexec
-  MPIEXEC_CANDIDATES=($(find "${MPICC%/*}" -name 'mpiexec' -o -name 'mpirun'))
+  MPIEXEC_CANDIDATES=($(find "${MPICC%/*}" -name 'mpiexec' -o -name 'mpirun' -o -name 'lamexec' -o -name 'srun'))
   if ! ((${#MPIEXEC_CANDIDATES[@]} >= 1)); then
     emergency "Could not find a suitable \`mpiexec\` in directory containing mpi wrappers (${MPICC%/*})"
   else


### PR DESCRIPTION
 Fixes #359

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

| Avg response time                 | coverage on master         |
| --------------------------------- | ---------------------------|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage]|

## Summary of changes ##

Hunt for `mpiexec` or `mpirun` in the same directory that `MPICC` and `MPIFC` are in when building with `install.sh` and then pass `-DMPIEXEC=...` to CMake so that the proper runtime environment is used...

## Rationale for changes ##

In some cases mpiexec was getting pulled in from the user's `PATH` and differed from the MPI implementation selected by the build script. This caused incompatibilities since `mpiexec`/`mpirun` from a different MPI implementation than the one used to compile was  being used.

## Additional info and certifications ##

This pull request (PR) is a:
 - [x] Bug fix
 - [ ] Feature addition
 - [ ] Other, Please describe:

I certify that:

 - [x] I have reviewed the [contributing guidelines]
 - [x] If this PR is a work in progress I have added `WIP:` to the
       beginning of the PR title
 - [x] If this PR is problematic for any reason, I have added
       `DO NOT MERGE:` to the beginning of the title
 - [x] The branch name and title of this PR contains the text
       `issue-<#>` where `<#>` is replaced by the issue that this PR
       is addressing
 - [x] I have deleted trailing white space on any lines that this PR
       touches
 - [x] I have used spaces for indentation on any lines that this PR
       touches
 - [x] I have included some comments to explain non-obvious code
       changes
 - [x] I have run the tests localy (`ctest`) and all tests pass
 - [x] Each commit is a logically atomic, self-consistent, cohesive
       set of changes
 - [x] The [commit message] should follow [these guidelines]:
     - [x] First line is directive phrase, starting with a capitalized
           imperative verb, and is no longer than 50 characters
           summarizing your commit
     - [x] Next line, if necessary is blank
     - [x] Following lines are all wrapped at 72 characters and can
           include additional paragraphs, bulleted lists, etc.
     - [x] Use [Github keywords] where appropriate, to indicate the
           commit resolves an open issue.
 - [x] I have signed  [Contributor License Agreement (CLA)] by
       clicking the "details" link to the right of the `licence/cla`
       check and following the directions on the CLA assistant webpage
 - [x] I have ensured that the test coverage hasn't gone down and added new [unit tests] to cover an new code added to the library


## For contributors and SI team members with code review priviledges ##

 - [x] I certify that I will wait 24 hours before self-approving via
       [pullapprove comment] or [Github code review] so that someone
       else has the chance to review my proposed changes

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[commit message]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[these guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[Contributor License Agreement (CLA)]: https://cla-assistant.io/sourceryinstitute/OpenCoarrays
[pullapprove comment]: https://pullapprove.com/sourceryinstitute/OpenCoarrays/settings/
[Github code review]: https://help.github.com/articles/about-pull-request-reviews/
[Github keywords]: https://help.github.com/articles/closing-issues-via-commit-messages/
[unit tests]: https://github.com/sourceryinstitute/OpenCoarrays/tree/master/src/tests/unit
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square