### PR TITLE
Check for and remove `noexecstack` added by MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,28 @@ this to the OpenCoarrays developers by filing a new issue at:
 https://github.com/sourceryinstitute/OpenCoarrays/issues/new")
 endif()
 
+#-----------------------------------------------
+# Work around bug #317 present on fedora systems
+#-----------------------------------------------
+if( (MPI_C_LINK_FLAGS MATCHES "noexecstack") OR (MPI_Fortran_LINK_FLAGS MATCHES "noexecstack") )
+  message ( WARNING
+"The `noexecstack` linker flag was found in the MPI_<lang>_LINK_FLAGS variable. This is
+known to cause segmentation faults for some Fortran codes. See, e.g.,
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71729 or
+https://github.com/sourceryinstitute/OpenCoarrays/issues/317.
+
+`noexecstack` is being replaced with `execstack`"
+    )
+  string(REPLACE "noexecstack"
+    "execstack" MPI_C_LINK_FLAGS_FIXED ${MPI_C_LINK_FLAGS})
+  string(REPLACE "noexecstack"
+    "execstack" MPI_Fortran_LINK_FLAGS_FIXED ${MPI_Fortran_LINK_FLAGS})
+  set(MPI_C_LINK_FLAGS "${MPI_C_LINK_FLAGS_FIXED}" CACHE STRING
+    "MPI C linking flags" FORCE)
+  set(MPI_Fortran_LINK_FLAGS "${MPI_Fortran_LINK_FLAGS_FIXED}" CACHE STRING
+    "MPI Fortran linking flags" FORCE)
+endif()
+
 #--------------------------------------------------------
 # Make sure a simple "hello world" C mpi program compiles
 #--------------------------------------------------------


### PR DESCRIPTION

| Avg response time                 | coverage on master         |
| --------------------------------- | ---------------------------|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage]|

## Summary of changes ##

Search for `noexecstack` in `MPI_<lang>_LINK_FLAGS` and if found issue a warning and overwrite with `execstack` due to #317

## Rationale for changes ##

`-Wl,-z,noexecstack` seems to cause segfaults in the GFortran runtime, e.g., when internal `contains` procedures are used.

 For additional details see:

 - #317
 - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71729#c1
 - https://github.com/sourceryinstitute/OpenCoarrays/issues/172#issuecomment-271582653

 #317 is triggered on Fedora 25
 Fixes #317

## Additional info and certifications ##

This pull request (PR) is a:
 - [x] Bug fix
 - [ ] Feature addition
 - [ ] Other, Please describe:

I certify that:

 - [x] I have reviewed the [contributing guidelines]
 - [x] If this PR is a work in progress I have added `WIP:` to the
       beginning of the PR title
 - [x] If this PR is problematic for any reason, I have added
       `DO NOT MERGE:` to the beginning of the title
 - [x] The branch name and title of this PR contains the text
       `issue-<#>` where `<#>` is replaced by the issue that this PR
       is addressing
 - [x] I have deleted trailing white space on any lines that this PR
       touches
 - [x] I have used spaces for indentation on any lines that this PR
       touches
 - [x] I have included some comments to explain non-obvious code
       changes
 - [x] I have run the tests localy (`ctest`) and all tests pass
 - [x] Each commit is a logically atomic, self-consistent, cohesive
       set of changes
 - [x] The [commit message] should follow [these guidelines]:
     - [x] First line is directive phrase, starting with a capitalized
           imperative verb, and is no longer than 50 characters
           summarizing your commit
     - [x] Next line, if necessary is blank
     - [x] Following lines are all wrapped at 72 characters and can
           include additional paragraphs, bulleted lists, etc.
     - [x] Use [Github keywords] where appropriate, to indicate the
           commit resolves an open issue.
 - [x] I have signed  [Contributor License Agreement (CLA)] by
       clicking the "details" link to the right of the `licence/cla`
       check and following the directions on the CLA assistant webpage
 - [x] I have ensured that the test coverage hasn't gone down and added new [unit tests] to cover an new code added to the library


## For contributors and SI team members with code review priviledges ##

 - [x] I certify that I will wait 24 hours before self-approving via
       [pullapprove comment] or [Github code review] so that someone
       else has the chance to review my proposed changes

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[commit message]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[these guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[Contributor License Agreement (CLA)]: https://cla-assistant.io/sourceryinstitute/OpenCoarrays
[pullapprove comment]: https://pullapprove.com/sourceryinstitute/OpenCoarrays/settings/
[Github code review]: https://help.github.com/articles/about-pull-request-reviews/
[Github keywords]: https://help.github.com/articles/closing-issues-via-commit-messages/
[unit tests]: https://github.com/sourceryinstitute/OpenCoarrays/tree/master/src/tests/unit
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square
