### PR TITLE
Fix typo in top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,15 @@ endif()
 find_package( MPI )
 
 if ( (NOT MPI_C_FOUND) OR (NOT MPI_Fortran_FOUND) OR (NOT MPIEXEC))
+  # Get default install location of MPICH from install.sh
+  execute_process( COMMAND "./install.sh" -P mpich
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE DEFAULT_MPICH_INSTALL_LOC
+    OUTPUT_QUIET
+    OUTPUT_STRIP_TRAILING_WHITES_SPACE
+  )
   find_program (MY_MPI_EXEC NAMES mpirun mpiexec lamexec srun
-    PATHS "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/3.1.4" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" ENV PATH
+    PATHS "${DEFAULT_MPICH_INSTALL_LOC}" ENV PATH
     HINTS "${FTN_COMPILER_DIR}" "${C_COMPILER_DIR}"
     PATH_SUFFIXES bin)
   set ( MPI_HOME "${MPI_HOME}" "${MY_MPI_EXEC}" "${MY_MPI_EXEC}/.." )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ find_package( MPI )
 
 if ( (NOT MPI_C_FOUND) OR (NOT MPI_Fortran_FOUND) OR (NOT MPIEXEC))
   find_program (MY_MPI_EXEC NAMES mpirun mpiexec lamexec srun
-    PATHS "${CMAKE_SOURCE_DIR/prerequisites/installations/mpich/3.1.4}" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" ENV PATH
+    PATHS "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/3.1.4" "${CMAKE_SOURCE_DIR}/prerequisites/installations/mpich/*" ENV PATH
     HINTS "${FTN_COMPILER_DIR}" "${C_COMPILER_DIR}"
     PATH_SUFFIXES bin)
   set ( MPI_HOME "${MPI_HOME}" "${MY_MPI_EXEC}" "${MY_MPI_EXEC}/.." )

--- a/prerequisites/install-functions/build_opencoarrays.sh
+++ b/prerequisites/install-functions/build_opencoarrays.sh
@@ -23,7 +23,8 @@ build_opencoarrays()
   # Set CC to the MPI implementation's gcc command...
   CC="${MPICC_show[0]}"
   # try to find mpiexec
-  MPIEXEC_CANDIDATES=($(find "${MPICC%/*}" -name 'mpiexec' -o -name 'mpirun' -o -name 'lamexec' -o -name 'srun'))
+  MPI_BIN_DIR="$(type -P "${MPICC}")"
+  MPIEXEC_CANDIDATES=($(find "${MPI_BIN_DIR%/*}" -name 'mpiexec' -o -name 'mpirun' -o -name 'lamexec' -o -name 'srun'))
   if ! ((${#MPIEXEC_CANDIDATES[@]} >= 1)); then
     emergency "Could not find a suitable \`mpiexec\` in directory containing mpi wrappers (${MPICC%/*})"
   else


### PR DESCRIPTION
This edit implements the suggestion in the first comment
of CMake issue 16804 posted at
https://gitlab.kitware.com/cmake/cmake/issues/16804

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

| Avg response time                 | coverage on master         |
| --------------------------------- | ---------------------------|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage]|

## Summary of changes ##

Corrected typo in CMakeLists.txt

## Rationale for changes ##

See the first comment in [CMake issue 16804](https://gitlab.kitware.com/cmake/cmake/issues/16804).
 
## Additional info and certifications ##

This pull request (PR) is a:
 - [X] Bug fix

I certify that:

 - [X] I have reviewed the [contributing guidelines]
 - [X] The branch name and title of this PR contains the text
       `issue-<#>` where `<#>` is replaced by the issue that this PR
       is addressing
 - [X] I have deleted trailing white space on any lines that this PR
       touches
 - [ ] I have run the tests localy (`ctest`) and all tests pass
 - [X] Each commit is a logically atomic, self-consistent, cohesive
       set of changes
 - [X] The [commit message] should follow [these guidelines]:
     - [X] First line is directive phrase, starting with a capitalized
           imperative verb, and is no longer than 50 characters
           summarizing your commit
     - [X] Next line, if necessary is blank
     - [X] Following lines are all wrapped at 72 characters and can
           include additional paragraphs, bulleted lists, etc.
 - [X] I have signed  [Contributor License Agreement (CLA)] by
       clicking the "details" link to the right of the `licence/cla`
       check and following the directions on the CLA assistant webpage
 - [ ] I have ensured that the test coverage hasn't gone down and added new [unit tests] to cover an new code added to the library

## For contributors and SI team members with code review priviledges ##

 - [X] I certify that I will wait 24 hours before self-approving via
       [pullapprove comment] or [Github code review] so that someone
       else has the chance to review my proposed changes

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[commit message]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[these guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[Contributor License Agreement (CLA)]: https://cla-assistant.io/sourceryinstitute/OpenCoarrays
[pullapprove comment]: https://pullapprove.com/sourceryinstitute/OpenCoarrays/settings/
[Github code review]: https://help.github.com/articles/about-pull-request-reviews/
[Github keywords]: https://help.github.com/articles/closing-issues-via-commit-messages/
[unit tests]: https://github.com/sourceryinstitute/OpenCoarrays/tree/master/src/tests/unit
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square