### PR TITLE
Fix application of patch for MPICH 3.2

### DIFF
--- a/prerequisites/build-functions/build_and_install.sh
+++ b/prerequisites/build-functions/build_and_install.sh
@@ -24,7 +24,8 @@ build_and_install()
     if [[ "${package_to_build}" == "mpich" && "${version_to_build}" == "3.2" ]]; then
       info "Patching MPICH 3.2 on Mac OS due to segfault bug (see http://lists.mpich.org/pipermail/discuss/2016-May/004764.html)."
       sed 's/} MPID_Request ATTRIBUTE((__aligned__(32)));/} ATTRIBUTE((__aligned__(32))) MPID_Request;/g' \
-        "${download_path}/${package_source_directory}/src/include/mpiimpl.h"
+        "${download_path}/${package_source_directory}/src/include/mpiimpl.h" > "${download_path}/${package_source_directory}/src/include/mpiimpl.h.patched"
+      cp "${download_path}/${package_source_directory}/src/include/mpiimpl.h.patched" "${download_path}/${package_source_directory}/src/include/mpiimpl.h"
     fi
 
     info "Configuring ${package_to_build} ${version_to_build} with the following command:"


### PR DESCRIPTION
Small bug fix to make a66121a9b576044ee070cd178a8a7f40837f1c0c and 3947bdb1e6fe6abffa23868121ece9fb9055e206 work together correctly. 3947bdb1e6fe6abffa23868121ece9fb9055e206 had a non-portable sed usage and a66121a9b576044ee070cd178a8a7f40837f1c0c caused the patch to not actually get applied.