### PR TITLE
add missing space for cafrun -w option

### DIFF
--- a/src/extensions/cafrun-foot
+++ b/src/extensions/cafrun-foot
@@ -39,7 +39,7 @@ elif [[ $1 == '-v' || $1 == '-V' || $1 == '--version' ]]; then
   echo "the file named LICENSE."
   echo ""
 elif [[ $1 == '-w' || $1 == '--wraps' ]]; then
-  "${CAFRUN}"-v
+  "${CAFRUN}" -v
 elif [[ $1 == '-h' || $1 == '--help' ]]; then
   usage
 else


### PR DESCRIPTION
This calls mpiexec -v

| Avg response time                 | coverage on master         |
| --------------------------------- | ---------------------------|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage]|

## Summary of changes ##
This is a trivial change that fixes the cafrun wrapper script if called with -w or --wraps option.

Summarize what you changed
I have added one space
## Rationale for changes ##
cafrun -w produced this error:
cafrun: line 80: /opt/ohpc/pub/mpi/openmpi-gnu/1.10.6/bin/mpiexec-v: No such file or directory

## Additional info and certifications ##

This pull request (PR) is a:
 - [x] Bug fix
 - [ ] Feature addition
 - [ ] Other, Please describe:

I certify that:

 - [x] I have reviewed the [contributing guidelines]
 - [ ] If this PR is a work in progress I have added `WIP:` to the
       beginning of the PR title
 - [ ] If this PR is problematic for any reason, I have added
       `DO NOT MERGE:` to the beginning of the title
 - [ ] The branch name and title of this PR contains the text
       `issue-<#>` where `<#>` is replaced by the issue that this PR
       is addressing
 - [ ] I have deleted trailing white space on any lines that this PR
       touches
 - [ ] I have used spaces for indentation on any lines that this PR
       touches
 - [ ] I have included some comments to explain non-obvious code
       changes
 - [x] I have run the tests localy (`ctest`) and all tests pass
 - [ ] Each commit is a logically atomic, self-consistent, cohesive
       set of changes
 - [ ] The [commit message] should follow [these guidelines]:
     - [ ] First line is directive phrase, starting with a capitalized
           imperative verb, and is no longer than 50 characters
           summarizing your commit
     - [ ] Next line, if necessary is blank
     - [ ] Following lines are all wrapped at 72 characters and can
           include additional paragraphs, bulleted lists, etc.
     - [ ] Use [Github keywords] where appropriate, to indicate the
           commit resolves an open issue.
 - [x] I have signed  [Contributor License Agreement (CLA)] by
       clicking the "details" link to the right of the `licence/cla`
       check and following the directions on the CLA assistant webpage
 - [ ] I have ensured that the test coverage hasn't gone down and added new [unit tests] to cover an new code added to the library


## For contributors and SI team members with code review priviledges ##

 - [ ] I certify that I will wait 24 hours before self-approving via
       [pullapprove comment] or [Github code review] so that someone
       else has the chance to review my proposed changes

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[commit message]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[these guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[Contributor License Agreement (CLA)]: https://cla-assistant.io/sourceryinstitute/OpenCoarrays
[pullapprove comment]: https://pullapprove.com/sourceryinstitute/OpenCoarrays/settings/
[Github code review]: https://help.github.com/articles/about-pull-request-reviews/
[Github keywords]: https://help.github.com/articles/closing-issues-via-commit-messages/
[unit tests]: https://github.com/sourceryinstitute/OpenCoarrays/tree/master/src/tests/unit
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square
