### PR TITLE
Fix issue-385: correct cmake path in report_results.sh 

### DIFF
--- a/prerequisites/install-functions/report_results.sh
+++ b/prerequisites/install-functions/report_results.sh
@@ -15,7 +15,7 @@ report_results()
 
   type_CMAKE=`type ${CMAKE}`
   fully_qualified_CMAKE="/${type_CMAKE#*/}"
-  cmake_install_path="${fully_qualified_CMAKE%%/cmake*}"
+  cmake_install_path="${fully_qualified_CMAKE%%bin/cmake*}"
 
   # Report installation success or failure and record locations for software stack:
   if [[ -x "${install_path%/}/bin/caf" && -x "${install_path%/}/bin/cafrun" ]]; then
@@ -45,14 +45,14 @@ report_results()
     echo "# Execute this script via the following command:                                " | tee -a setup.csh setup.sh
     echo "# source ${install_path%/}/setup.sh                                             " | tee -a setup.csh setup.sh
     echo "                                                                                " | tee -a setup.csh setup.sh
-    if [[ -x "$cmake_install_path/cmake" ]]; then
+    if [[ -x "${cmake_install_path}/bin/cmake" ]]; then
       echo "# Prepend the CMake path to the PATH environment variable:" | tee -a setup.sh setup.csh
       echo "if [[ -z \"\$PATH\" ]]; then                                         " >> setup.sh
-      echo "  export PATH=\"${cmake_install_path%/}/\"                            " >> setup.sh
+      echo "  export PATH=\"${cmake_install_path%/}/bin\"                        " >> setup.sh
       echo "else                                                                 " >> setup.sh
-      echo "  export PATH=\"${cmake_install_path%/}/\":\$PATH                     " >> setup.sh
+      echo "  export PATH=\"${cmake_install_path%/}/bin\":\$PATH                 " >> setup.sh
       echo "fi                                                                   " >> setup.sh
-      echo "set path = (\"${cmake_install_path%/}\"/\"\$path\")                      " >> setup.csh
+      echo "set path = (\"${cmake_install_path%/}\"/bin \"\$path\")              " >> setup.csh
     fi
     if [[ -x "$fully_qualified_FC" ]]; then
       echo "# Prepend the compiler path to the PATH environment variable:" | tee -a setup.sh setup.csh


### PR DESCRIPTION
<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

| Avg response time                 | coverage on master         |
| --------------------------------- | ---------------------------|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage]|

## Summary of changes ##

Fixed setting of `cmake_install_path` variable in `report_results.sh`.

## Rationale for changes ##

report_results.sh was setting the wrong path for cmake when the cmake binary is in a path that has the string "cmake" earlier in the path.

## Additional info and certifications ##

This pull request (PR) is a:
 - [X] Bug fix

I certify that:

 - [X] I have reviewed the [contributing guidelines]
 - [X] The branch name and title of this PR contains the text
       `issue-<#>` where `<#>` is replaced by the issue that this PR
       is addressing
 - [X] I have deleted trailing white space on any lines that this PR
       touches
 - [X] I have used spaces for indentation on any lines that this PR
       touches
 - [X] Each commit is a logically atomic, self-consistent, cohesive
       set of changes
 - [X] The [commit message] should follow [these guidelines]:
     - [X] First line is directive phrase, starting with a capitalized
           imperative verb, and is no longer than 50 characters
           summarizing your commit
     - [X] Use [Github keywords] where appropriate, to indicate the
           commit resolves an open issue.
 - [X] I have signed  [Contributor License Agreement (CLA)] by
       clicking the "details" link to the right of the `licence/cla`
       check and following the directions on the CLA assistant webpage

## For contributors and SI team members with code review priviledges ##

 - [X] I certify that I will wait 24 hours before self-approving via
       [pullapprove comment] or [Github code review] so that someone
       else has the chance to review my proposed changes

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[commit message]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[these guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[Contributor License Agreement (CLA)]: https://cla-assistant.io/sourceryinstitute/OpenCoarrays
[pullapprove comment]: https://pullapprove.com/sourceryinstitute/OpenCoarrays/settings/
[Github code review]: https://help.github.com/articles/about-pull-request-reviews/
[Github keywords]: https://help.github.com/articles/closing-issues-via-commit-messages/
[unit tests]: https://github.com/sourceryinstitute/OpenCoarrays/tree/master/src/tests/unit
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square
