### PR TITLE
Fix by replacing error_stop with terminate_internal.

### DIFF
--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -1809,14 +1809,14 @@ PREFIX (send) (caf_token_t token, size_t offset, int image_index,
       check_image_health (image_index, stat);
 
       if(!stat && ierr == STAT_FAILED_IMAGE)
-        error_stop (ierr);
+        terminate_internal (ierr, 1);
 
       if(stat)
         *stat = ierr;
 #else
       if (ierr != 0)
          {
-           error_stop (ierr);
+           terminate_internal (ierr, 1);
            return;
          }
 #endif
@@ -2112,14 +2112,14 @@ PREFIX (get) (caf_token_t token, size_t offset,
   if(stat)
     *stat = ierr;
   else if(ierr == STAT_FAILED_IMAGE)
-    error_stop (ierr);
+    terminate_internal (STAT_FAILED_IMAGE, 1);
 #else
   CAF_Win_unlock (image_index - 1, *p);
 
   if(stat)
     *stat = ierr;
   else if (ierr != 0)
-    error_stop (ierr);
+    terminate_internal (ierr, 1);
 #endif
 
   MPI_Type_free(&dt_s);
@@ -3607,7 +3607,7 @@ sync_images_internal (int count, int images[], int *stat, char *errmsg,
         {
           fprintf (stderr, "COARRAY ERROR: Invalid image index %d to SYNC "
                    "IMAGES", images[i]);
-          error_stop (1);
+          terminate_internal (1, 1);
         }
   }
 #endif


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Replaced calls to non-existent error_stop function (don't mix this up with PREFIX (error_stop)) with the internal_terminate.

## Rationale for changes ##

Allow compiling again.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I have reviewed the [contributing guidelines] and followed the
      policies on:
      - Pull request (PR) naming to indicate work in progress (WIP),
        and to attach the PR to the appropriate bug report, or feature
        request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Running tests locally, to ensure all of them pass
      - Maintaining or increasing test coverage
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the pull request to
        give another OpenCoarrays developer a chance to review my
        proposed code
