### PR TITLE
Fix #404 -m/--with-cmake overrides default cmake

### DIFF
--- a/install.sh-usage
+++ b/install.sh-usage
@@ -11,7 +11,7 @@
   -I --install-version [arg]  Install package version.
   -j --num-threads [arg]      Number of threads to use when invoking make. Default="1"
   -l --list-packages          Print packages this script can install.
-  -m --with-cmake [arg]       Use specified CMake installation. Default="cmake"
+  -m --with-cmake [arg]       Use specified CMake installation.
   -M --with-mpi [arg]         Use specified MPI installation.
   -n --no-color               Disable color output.
   -o --only-download          Download (without building) the source for the package specified by -p or --package.

--- a/prerequisites/install-functions/find_or_install.sh
+++ b/prerequisites/install-functions/find_or_install.sh
@@ -66,7 +66,17 @@ find_or_install()
     # Every branch that discovers an acceptable pre-existing installation must set the
     # CMAKE environment variable. Every branch must also manage the dependency stack.
 
-    if [[ "$script_installed_package" == true ]]; then
+    # If the user specified a CMake binary, use it
+    if [[ ! -z "${arg_m:-}" ]]; then
+
+      echo -e "$this_script: Using the $package specified by -m or --with-cmake: ${arg_m}\n"
+      export CMAKE="${arg_m}"
+      # Halt the recursion
+      stack_push dependency_pkg "none"
+      stack_push dependency_exe "none"
+      stack_push dependency_path "none"
+
+    elif [[ "$script_installed_package" == true ]]; then
       echo -e "$this_script: Using the $package installed by $this_script\n"
       export CMAKE=$package_install_path/bin/$executable
       stack_push dependency_pkg "none"


### PR DESCRIPTION

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Added conditional block in `find_or_install.sh` to check for and use the user-specified `cmake` before checking for the default `cmake` or a `cmake` in the `PATH`.

## Rationale for changes ##

See #404 

Why did you make these changes?

## Additional info and certifications ##

This pull request (PR) is a:

- [ ] Bug fix
- [X] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I have reviewed the [contributing guidelines] and followed the
      policies on:
      - Pull request (PR) naming to indicate work in progress (WIP),
        and to attach the PR to the appropriate bug report, or feature
        request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Running tests locally, to ensure all of them pass
      - Maintaining or increasing test coverage
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the pull request to
        give another OpenCoarrays developer a chance to review my
        proposed code