### PR TITLE
Switch GCC url tail `.bz2` ==> `.gz`

### DIFF
--- a/prerequisites/build-functions/set_or_print_url.sh
+++ b/prerequisites/build-functions/set_or_print_url.sh
@@ -52,7 +52,7 @@ set_or_print_url()
         gcc_tail="branches/${version_to_build}"
       fi
     else
-      gcc_tail="gcc-${version_to_build}.tar.bz2"
+      gcc_tail="gcc-${version_to_build}.tar.gz"
     fi
   fi
   package_url_tail=(

--- a/prerequisites/install-functions/download-all-prerequisites.sh
+++ b/prerequisites/install-functions/download-all-prerequisites.sh
@@ -16,7 +16,7 @@ function download_all_prerequisites()
     ./install.sh --package gcc  --only-download
     gcc_version=$(./install.sh -V gcc)
     cd prerequisites/downloads/
-    tar xf gcc-${gcc_version}.tar.bz2 || emergency "tar didn't work"
+    tar xf gcc-${gcc_version}.tar.[bg]z* || emergency "tar didn't work"
     listing=$(ls -lt)
     cd gcc-${gcc_version}
   fi


### PR DESCRIPTION
 - More portable (Gzip more common than bzip2)
 - No .bz2 files are present for 6.4 on GNU FTP server
 - Fixes #408

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Downloading GCC releases with install.sh now tries to fetch the more common/portable `.gz` tarballs instead of `.bz2` compressed tarballs which seem to be missing for some releases like 6.4

## Rationale for changes ##

Make it so that `./install.sh --package gcc --install-version 6.4.0 --install-prefix /packages/gcc/6.4.0` works

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I have reviewed the [contributing guidelines] and followed the
      policies on:
      - Pull request (PR) naming to indicate work in progress (WIP),
        and to attach the PR to the appropriate bug report, or feature
        request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Running tests locally, to ensure all of them pass
      - Maintaining or increasing test coverage
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the pull request to
        give another OpenCoarrays developer a chance to review my
        proposed code