### PR TITLE
Add logic to install Xcode-CLT if needed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -234,6 +234,9 @@ source $opencoarrays_src_dir/prerequisites/install-functions/build_opencoarrays.
 # shellcheck source=./prerequisites/install-functions/report_results.sh
 source $opencoarrays_src_dir/prerequisites/install-functions/report_results.sh
 
+# shellcheck source=./prerequisites/install-functions/install-xcode-clt.sh
+source "${opencoarrays_src_dir}/prerequisites/install-functions/install-xcode-clt.sh"
+
 # ___________________ End of function definitions for use in the Main Body __________________
 
 
@@ -303,6 +306,8 @@ elif [[ "${arg_p:-}" == "opencoarrays" ]]; then
 
   else
 
+    # Install Xcode command line tools (CLT) if on macOS and if needed
+    maybe_install_xcodeCLT
     # Install OpenCoarrays
     cd prerequisites || exit 1
     installation_record=install-opencoarrays.log
@@ -320,11 +325,17 @@ elif [[ "${arg_p:-}" == "opencoarrays" ]]; then
 
 elif [[ "${arg_p:-}" == "ofp" ]]; then
 
+  # Install Xcode command line tools (CLT) if on macOS and if needed
+  maybe_install_xcodeCLT
+
   info "Invoking Open Fortran Parser build script with the following command:"
   info "\"${opencoarrays_src_dir}\"/prerequisites/install-ofp.sh"
   "${opencoarrays_src_dir}"/prerequisites/install-ofp.sh
 
 elif [[ ! -z "${arg_p:-}" ]]; then
+
+  # Install Xcode command line tools (CLT) if on macOS and if needed
+  maybe_install_xcodeCLT
 
   info "Invoking build script with the following command:"
   info "\"${opencoarrays_src_dir}\"/prerequisites/build.sh ${*:-}"

--- a/prerequisites/install-functions/install-xcode-clt.sh
+++ b/prerequisites/install-functions/install-xcode-clt.sh
@@ -4,7 +4,7 @@ need_xcodeCLT() {
     echo "false"
   else
     local xcode_dir
-    xcode_dir="$(/usr/bin/xcode-select -print-path 2>/dev/null)"
+    xcode_dir="$(/usr/bin/xcode-select -print-path 2>/dev/null)" || true
     if [[ ! -d "${xcode_dir}" || ! -x "${xcode_dir}/usr/bin/make" ]]; then
       echo "true"
     else
@@ -14,41 +14,44 @@ need_xcodeCLT() {
 }
 
 xcode_clt_install () {
-  info "It appears that you are on Mac OS and do not have the Xcode command line tools (CLT) installed."
-  app_store_label="$(softwareupdate -l | grep -B 1 -E "Command Line (Developer|Tools)" | awk -F"*" '/^ +\\*/ {print $2}' | sed 's/^ *//' | tail -n1)"
+  app_store_label="$(softwareupdate -l | grep -B 1 -E "Command Line (Developer|Tools)" | awk -F"*" '/^ +\\*/ {print $2}' | sed 's/^ *//' | tail -n1)" || return 0
   if [[ "${arg_y}" == "${__flag_present}" ]]; then
     info "-y or --yes-to-all flag present. Proceeding with non-interactive download and install."
   else
+    info "If you proceed with the Xcode-CLT installation you may be prompted for your password."
     printf "Ready to install %s? (Y/n)" "${app_store_label}"
     read -r install_xcodeclt
     printf '%s\n' "${install_xcodeclt}"
     if [[ "${install_xcodeclt}" == [nN]* ]]; then
-      emergency "${this_script}: Aborting: cannot procede without XCode CLT."
+      emergency "${this_script}: Aborting: cannot proceed without XCode CLT."
     fi
   fi
-  info "We will attempt to download and install XCode CLT for you now. Note: sudo priveledges required"
+  info "install.sh will attempt to download and install XCode CLT for you now."
+  info "Note: sudo privileges required. Please enter your password if prompted."
   place_holder="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
   sudo /usr/bin/touch "${place_holder}" || true
-  sudo /usr/sbin/softwareupdate -i app_store_label || true
+  sudo /usr/sbin/softwareupdate -i app_store_label || return 0
   sudo /bin/rm -f "${place_holder}" || true
-  sudo /usr/bin/xcode-select --switch "/Library/Developer/CommandLineTools" || true
+  sudo /usr/bin/xcode-select --switch "/Library/Developer/CommandLineTools" || return 1
 }
 
 headless_xcode_clt_install () {
-  # Fallback her if headless install failed
+  # Fallback here if headless install/upgrade failed. This is the usual path through this code.
   if [[ "${arg_y}" == "${__flag_present}" ]]; then
     info "-y or --yes-to-all flag present. Proceeding with non-interactive download and install."
   else
+    info "If you proceed with the Xcode-CLT installation you may be prompted for your password."
     printf "Ready to install Xcode-CLT using xcode-select? (Y/n)"
     read -r install_xcodeclt
     printf '%s\n' "${install_xcodeclt}"
     if [[ "${install_xcodeclt}" == [nN]* ]]; then
-      emergency "${this_script}: Aborting: cannot procede without XCode CLT."
+      emergency "${this_script}: Aborting: cannot proceed without XCode CLT."
     fi
   fi
-  info "Installing Xcode Command Line Tools (CLE), please follow instructions on popup window."
+  info "Installing Xcode Command Line Tools (CLT), using \`xcode-select --install\`."
+  info "Note: sudo privileges required. Please enter your password if prompted."
   sudo /usr/bin/xcode-select --install || emergency "${this_script}: unable to run \`sudo xcode-select --install\`"
-  printf "Press <enter> once installation has completed"
+  printf "Please press <enter> once installation of Xcode command line tools has completed."
   read -r
   sudo /usr/bin/xcode-select --switch "/Library/Developer/CommandLineTools" || \
     emergency "${this_script}: Xcode-CLT installation and activation failed, unable to continue"
@@ -56,15 +59,17 @@ headless_xcode_clt_install () {
 
 maybe_install_xcodeCLT () {
   if [[ "$(need_xcodeCLT)" == "true" ]]; then
-    xcode_clt_install
+    info "It appears that you are on Mac OS and do not have the Xcode command line tools (CLT) installed, or they need to be upgraded."
+    info "install.sh will now attempt to install/upgrade the Xcode-CLT using \`softwareupdate\`"
+    xcode_clt_install || true # This usually fails since `softwareupdate -i` doesn't return CLTs needing update
   fi
   if [[ "$(need_xcodeCLT)" == "true" ]]; then
-    info "First Xcode-CLT installation failed, trying another method"
-    headless_xcode_clt_install
+    info "\`softwareupdate\` installation/upgrade failed. This is normal. Now trying with \`xcode-select --install\`"
+    headless_xcode_clt_install || emergency "${this_script}: Could not install Xcode command line tools, unable to proceed. Please install them via the app store before retrying this installation."
   fi
 
   clang_output="$(/usr/bin/xzrun clang 2>&1)" || true
   if [[ "${clang_output}" =~ license ]]; then
-    emergency "${this_script}: It appears you have not agreed to the Xcode license. Please do so before attempting to run this script again. This may be acheived by opening Xcode.app or running \`sudo xcodebuild -license\`"
+    emergency "${this_script}: It appears you have not agreed to the Xcode license. Please do so before attempting to run this script again. This may be achieved by opening Xcode.app or running \`sudo xcodebuild -license\`"
   fi
 }

--- a/prerequisites/install-functions/install-xcode-clt.sh
+++ b/prerequisites/install-functions/install-xcode-clt.sh
@@ -59,8 +59,9 @@ headless_xcode_clt_install () {
 
 maybe_install_xcodeCLT () {
   if [[ "$(need_xcodeCLT)" == "true" ]]; then
-    info "It appears that you are on Mac OS and do not have the Xcode command line tools (CLT) installed, or they need to be upgraded."
-    info "install.sh will now attempt to install/upgrade the Xcode-CLT using \`softwareupdate\`"
+    info "It appears that you are on Mac OS and do not have the Xcode command line tools (CLT) installed,"
+    info "or they need to be upgraded.install.sh will now attempt to install/upgrade the Xcode-CLT using \`softwareupdate\`"
+    info "This may take some time, please be patient."
     xcode_clt_install || true # This usually fails since `softwareupdate -i` doesn't return CLTs needing update
   fi
   if [[ "$(need_xcodeCLT)" == "true" ]]; then

--- a/prerequisites/install-functions/install-xcode-clt.sh
+++ b/prerequisites/install-functions/install-xcode-clt.sh
@@ -1,0 +1,70 @@
+# shellcheck shell=bash disable=SC2154,SC2148
+need_xcodeCLT() {
+  if [[ "${OSTYPE}" != [Dd][Aa][Rr][Ww][Ii][Nn]* ]]; then
+    echo "false"
+  else
+    local xcode_dir
+    xcode_dir="$(/usr/bin/xcode-select -print-path 2>/dev/null)"
+    if [[ ! -d "${xcode_dir}" || ! -x "${xcode_dir}/usr/bin/make" ]]; then
+      echo "true"
+    else
+      echo "false"
+    fi
+  fi
+}
+
+xcode_clt_install () {
+  info "It appears that you are on Mac OS and do not have the Xcode command line tools (CLT) installed."
+  app_store_label="$(softwareupdate -l | grep -B 1 -E "Command Line (Developer|Tools)" | awk -F"*" '/^ +\\*/ {print $2}' | sed 's/^ *//' | tail -n1)"
+  if [[ "${arg_y}" == "${__flag_present}" ]]; then
+    info "-y or --yes-to-all flag present. Proceeding with non-interactive download and install."
+  else
+    printf "Ready to install %s? (Y/n)" "${app_store_label}"
+    read -r install_xcodeclt
+    printf '%s\n' "${install_xcodeclt}"
+    if [[ "${install_xcodeclt}" == [nN]* ]]; then
+      emergency "${this_script}: Aborting: cannot procede without XCode CLT."
+    fi
+  fi
+  info "We will attempt to download and install XCode CLT for you now. Note: sudo priveledges required"
+  place_holder="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+  sudo /usr/bin/touch "${place_holder}" || true
+  sudo /usr/sbin/softwareupdate -i app_store_label || true
+  sudo /bin/rm -f "${place_holder}" || true
+  sudo /usr/bin/xcode-select --switch "/Library/Developer/CommandLineTools" || true
+}
+
+headless_xcode_clt_install () {
+  # Fallback her if headless install failed
+  if [[ "${arg_y}" == "${__flag_present}" ]]; then
+    info "-y or --yes-to-all flag present. Proceeding with non-interactive download and install."
+  else
+    printf "Ready to install Xcode-CLT using xcode-select? (Y/n)"
+    read -r install_xcodeclt
+    printf '%s\n' "${install_xcodeclt}"
+    if [[ "${install_xcodeclt}" == [nN]* ]]; then
+      emergency "${this_script}: Aborting: cannot procede without XCode CLT."
+    fi
+  fi
+  info "Installing Xcode Command Line Tools (CLE), please follow instructions on popup window."
+  sudo /usr/bin/xcode-select --install || emergency "${this_script}: unable to run \`sudo xcode-select --install\`"
+  printf "Press <enter> once installation has completed"
+  read -r
+  sudo /usr/bin/xcode-select --switch "/Library/Developer/CommandLineTools" || \
+    emergency "${this_script}: Xcode-CLT installation and activation failed, unable to continue"
+}
+
+maybe_install_xcodeCLT () {
+  if [[ "$(need_xcodeCLT)" == "true" ]]; then
+    xcode_clt_install
+  fi
+  if [[ "$(need_xcodeCLT)" == "true" ]]; then
+    info "First Xcode-CLT installation failed, trying another method"
+    headless_xcode_clt_install
+  fi
+
+  clang_output="$(/usr/bin/xzrun clang 2>&1)" || true
+  if [[ "${clang_output}" =~ license ]]; then
+    emergency "${this_script}: It appears you have not agreed to the Xcode license. Please do so before attempting to run this script again. This may be acheived by opening Xcode.app or running \`sudo xcodebuild -license\`"
+  fi
+}


### PR DESCRIPTION
On macOS, add logic to install script that will install Xcode command
 line tools. Most logic cribbed from Homebrew installer.

 Fixes #325

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

If on macOS and using `install.sh`, determine if Xcode command line tools (CLT) are already installed and try to install them if they are needed.

## Rationale for changes ##

Help novice/new macOS users get their dev environment setup for development, including using OpenCoarrays. Without this, a user could download OpenCoarrays on macOS and not be able to install all the required software. `install.sh` trie to cater to the lowest common denominator, and most novice user, so it tries to be as seamless and easy as possible.

## Additional info and certifications ##

This pull request (PR) is a:

- [ ] Bug fix
- [x] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I have reviewed the [contributing guidelines] and followed the
      policies on:
      - Pull request (PR) naming to indicate work in progress (WIP),
        and to attach the PR to the appropriate bug report, or feature
        request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Running tests locally, to ensure all of them pass
      - Maintaining or increasing test coverage
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the pull request to
        give another OpenCoarrays developer a chance to review my
        proposed code
