### PR TITLE
Fix bug & improve Windows support

### DIFF
--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
-if (MINGW)
-  add_definitions(-D_POSIX)
-endif()
-
 if (NOT MPI_C_FOUND)
   find_package(MPI REQUIRED)
 
@@ -42,8 +38,32 @@ endif()
 #----------------------------------------------------------------------
 # Test if MPI implementation provides features needed for failed images
 #----------------------------------------------------------------------
-set(NEEDED_SYMBOLS MPIX_ERR_PROC_FAILED;MPIX_ERR_REVOKED;MPIX_Comm_failure_ack;MPIX_Comm_failure_get_acked;MPIX_Comm_shrink;MPIX_Comm_agree)
 set(MPI_HAS_FAULT_TOL_EXT YES)
+
+CHECK_INCLUDE_FILE("signal.h" HAVE_SIGNAL_H)
+if (NOT HAVE_SIGNAL_H)
+  set(MPI_HAS_FAULT_TOL_EXT NO)
+  message( FATAL_ERROR "Currently, OpenCoarrays cannot build without signal.h")
+endif()
+
+include(CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(SIGKILL "signal.h" HAVE_SIGKILL)
+if(NOT HAVE_SIGKILL) # try -D_POSIX, needed for mingw-w64, maybe others, see #435
+                     # https://github.com/sourceryinstitute/OpenCoarrays/issues/435#issuecomment-323592433
+  list( APPEND CMAKE_REQUIRED_DEFINITIONS -D_POSIX)
+  CHECK_SYMBOL_EXISTS(SIGKILL "signal.h" HAVE_SIGKILL)
+  if(HAVE_SIGKILL)
+    add_definitions(-D_POSIX)
+  endif()
+endif()
+
+if (NOT HAVE_SIGKILL)
+  set(MPI_HAS_FAULT_TOL_EXT NO)
+  message (FATAL_ERROR "Currently, OpenCoarrays cannot build without SIGKILL from signal.h")
+endif()
+
+set(NEEDED_SYMBOLS MPIX_ERR_PROC_FAILED;MPIX_ERR_REVOKED;MPIX_Comm_failure_ack;MPIX_Comm_failure_get_acked;MPIX_Comm_shrink;MPIX_Comm_agree)
+
 set(old_cmake_required_includes "${CMAKE_REQUIRED_INCLUDES}")
 if(CMAKE_REQUIRED_INCLUDES)
   set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES};${MPI_C_INCLUDE_PATH})
@@ -69,7 +89,7 @@ if(HAVE_MPI_EXT)
   add_definitions(-DHAVE_MPI_EXT_H)
   set(MPI_HEADERS ${MPI_HEADERS};mpi-ext.h)
 endif()
-include(CheckSymbolExists)
+
 foreach(symbol ${NEEDED_SYMBOLS})
   CHECK_SYMBOL_EXISTS(${symbol} ${MPI_HEADERS} HAVE_${symbol})
   if(NOT HAVE_${symbol})
@@ -92,6 +112,16 @@ endif()
 if(CAF_ENABLE_FAILED_IMAGES)
   add_definitions(-DUSE_FAILED_IMAGES)
 endif()
+
+#---------------------------------------------------
+# Windows Intel MPI compatibility, see GH issue #435
+#---------------------------------------------------
+CHECK_SYMBOL_EXISTS(I_MPI_VERSION mpi.h HAVE_Intel_MPI)
+if(HAVE_Intel_MPI AND WIN32)
+  add_definitions(-DUSE_GCC)
+endif()
+
+
 
 # Determine whether and how to include OpenCoarrays module based on if the Fortran MPI compiler:
 #   - workds

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
-if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-  add_definitions(-D_POSIX -DUSE_GCC)
+if (MINGW)
+  add_definitions(-D_POSIX)
 endif()
 
 if (NOT MPI_C_FOUND)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  add_definitions(-D_POSIX -DUSE_GCC)
+endif()
+
 if (NOT MPI_C_FOUND)
   find_package(MPI REQUIRED)
 

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -4136,7 +4136,7 @@ static void \
 redux_char_by_reference_adapter (void *invec, void *inoutvec, int *len,
       MPI_Datatype *datatype)
 {
-  long int string_len;
+  MPI_Aint string_len;
   MPI_Type_extent(*datatype, &string_len);
   for(int i = 0; i < *len; i++)
     {


### PR DESCRIPTION
 Based on tales of success by @jbmaggard in issue #435
 Fixes #435
 Error in the type def of an argument to `MPI_Type_extent`
 `long int string_len;` → `MPI_Aint string_len;` on `mpi_caf.c:4140`

[L4140]: https://github.com/sourceryinstitute/OpenCoarrays/blob/f7a5f2ebeaf935a67184a978bc40177e4399b82b/src/mpi/mpi_caf.c#L4140

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Fixed bug with improper type of argument to `MPI_Type_extent` found in #435 

## Rationale for changes ##

Build fails on windows vs MS-MPI using mingw GCC 7.1. Definitely a bug, regardless of whether or not it works on Windows, but add'l changes added to attempt to improve windows support.

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
