### PR TITLE
Descriptor fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,9 @@ endif()
   if ( gfortran_compiler AND ( NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 7.0.0 ) )
     add_definitions(-DGCC_GE_7) # Tell library to build against GFortran 7.x bindings b/c we might be using clang for C
   endif()
+  if ( gfortran_compiler AND ( NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 8.0.0 ) )
+    add_definitions(-DGCC_GE_8) # Tell library to build against GFortran 8.x bindings w/ descriptor change
+  endif()
 
 if(gfortran_compiler)
   set(OLD_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})

--- a/src/libcaf-gfortran-descriptor.h
+++ b/src/libcaf-gfortran-descriptor.h
@@ -51,6 +51,7 @@ typedef struct gfc_descriptor_t {
   void *base_addr;
   size_t offset;
   ptrdiff_t dtype;
+  ptrdiff_t span;
   descriptor_dimension dim[];
 } gfc_descriptor_t;
 

--- a/src/libcaf-gfortran-descriptor.h
+++ b/src/libcaf-gfortran-descriptor.h
@@ -51,7 +51,9 @@ typedef struct gfc_descriptor_t {
   void *base_addr;
   size_t offset;
   ptrdiff_t dtype;
+#ifdef GCC_GE_8
   ptrdiff_t span;
+#endif
   descriptor_dimension dim[];
 } gfc_descriptor_t;
 

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -2703,9 +2703,7 @@ copy_data (void *ds, mpi_caf_token_t *token, MPI_Aint offset, int dst_type,
     This typedef is made to allow storing a copy of a remote descriptor on the
     stack without having to care about the rank.  */
 typedef struct gfc_max_dim_descriptor_t {
-  void *base_addr;
-  size_t offset;
-  ptrdiff_t dtype;
+  gfc_descriptor_t base;
   descriptor_dimension dim[GFC_MAX_DIMENSIONS];
 } gfc_max_dim_descriptor_t;
 
@@ -3838,11 +3836,14 @@ PREFIX(is_present) (caf_token_t token, int image_index, caf_reference_t *refs)
                        MPI_BYTE, global_dynamic_win);
             }
 #ifdef EXTRA_DEBUG_OUTPUT
-          fprintf (stderr, "%d/%d: %s() remote desc rank: %d (ref_rank: %d)\n", caf_this_image, caf_num_images,
-                   __FUNCTION__, GFC_DESCRIPTOR_RANK (&src_desc), ref_rank);
-          for (i = 0; i < GFC_DESCRIPTOR_RANK (&src_desc); ++i)
-            fprintf (stderr, "%d/%d: %s() remote desc dim[%d] = (lb = %d, ub = %d, stride = %d)\n", caf_this_image, caf_num_images,
-                     __FUNCTION__, i, src_desc.dim[i].lower_bound, src_desc.dim[i]._ubound, src_desc.dim[i]._stride);
+          {
+            gfc_descriptor_t * src = (gfc_descriptor_t *)(&src_desc);
+            fprintf (stderr, "%d/%d: %s() remote desc rank: %d (ref_rank: %d)\n", caf_this_image, caf_num_images,
+                     __FUNCTION__, GFC_DESCRIPTOR_RANK (src), ref_rank);
+            for (i = 0; i < GFC_DESCRIPTOR_RANK (src); ++i)
+              fprintf (stderr, "%d/%d: %s() remote desc dim[%d] = (lb = %d, ub = %d, stride = %d)\n", caf_this_image, caf_num_images,
+                       __FUNCTION__, i, src_desc.dim[i].lower_bound, src_desc.dim[i]._ubound, src_desc.dim[i]._stride);
+          }
 #endif
 
           for (i = 0; riter->u.a.mode[i] != CAF_ARR_REF_NONE; ++i)


### PR DESCRIPTION
<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Update libcaf header for new component in array descriptor

## Rationale for changes ##

GCC 8.x added a new component to the array descriptor struct and if we don't match it, the OC tests fail

## Additional info and certifications ##

This pull request (PR) is a:

- [ ] Bug fix
- [ ] Feature addition
- [X] Other, Please describe: compatibility with GFortran udpate

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
