### PR TITLE
install.sh now detects present GCC branch tar ball

### DIFF
--- a/prerequisites/build-functions/download_if_necessary.sh
+++ b/prerequisites/build-functions/download_if_necessary.sh
@@ -68,8 +68,8 @@ download_if_necessary()
       ;;
    esac
   
-  if  [[ -f "${download_path}/${url_tail}" || -d "${download_path}/${url_tail}" ]] ; then
-    info "Found '${url_tail}' in ${download_path}."
+  if  [[ -f "${download_path}/${url_tail}" || -d "${download_path}/${url_tail##*branches/}" ]]; then
+    info "Found '${url_tail##*branches/}' in ${download_path}."
     info "If it resulted from an incomplete download, building ${package_name} could fail."
     if [[ "${arg_y}" == "${__flag_present}" ]]; then
       info "-y or --yes-to-all flag present. Proceeding with non-interactive build."
@@ -78,7 +78,7 @@ download_if_necessary()
       read -r proceed
       if [[ "${proceed}" == "n" || "${proceed}" == "N" || "${proceed}" == "no"  ]]; then
         info "n"
-        info "Please remove $url_tail and restart the installation to to ensure a fresh download." 1>&2
+        info "Please remove ${url_tail##*branches/} and restart the installation to to ensure a fresh download." 1>&2
         emergency "Aborting. [exit 80]"
       else
         info "y"


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Edited the file name that `install.sh` uses to detect previously downloaded GCC branches.

## Rationale for changes ##

With GCC branch downloads, the URL tail has the prefix `branches/`, which needs to be deleted when the tail is used as the file name for detecting a prior download.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], of which only the following apply because this only impacts the installation steps:
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code