### PR TITLE
Issue deprecation warning for FC=mpifort

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,9 +214,11 @@ get_filename_component( C_COMPILER_DIR "${CMAKE_C_COMPILER}"
   REALPATH )
 
 if (FTN_COMPILER_NAME MATCHES "^[mM][pP][iI]")
+  message( DEPRECATION "Setting the Fortran compiler to an MPI wrapper script is deprecated!")
   set (MPI_Fortran_COMPILER "${CMAKE_Fortran_COMPILER}")
 endif()
 if (C_COMPILER_NAME MATCHES "^[mM][pP][iI]")
+  message( DEPRECATION "Setting the Fortran compiler to an MPI wrapper script is deprecated!")
   set (MPI_C_COMPILER "${CMAKE_C_COMPILER}")
 endif()
 

--- a/src/extensions/caf.in
+++ b/src/extensions/caf.in
@@ -195,12 +195,16 @@ if [[ -n "${mpi_link_flags[*]:-}" ]]; then
 fi
 
 # Now do libraries, IN CORRECT ORDER, to append to command
-for lib in "${caf_libs[@]:-}"; do
-  caf_added_libs+=("${prefix%/}/${lib}")
-done
-for lib in "${mpi_libs[@]:-}"; do
-  caf_added_libs+=("${lib}")
-done
+if [[ -n "${caf_libs[*]:-}" ]]; then
+  for lib in "${caf_libs[@]:-}"; do
+    caf_added_libs+=("${prefix%/}/${lib}")
+  done
+fi
+if [[ -n "${mpi_libs[*]:-}" ]]; then
+  for lib in "${mpi_libs[@]:-}"; do
+    caf_added_libs+=("${lib}")
+  done
+fi
 
 usage() {
   echo ""


### PR DESCRIPTION
 - Also fix issue in CAF script arising from the use of FC=mpifort

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Very small tweak to correctly handle the case when users pass `FC=mpifort CC=mpicc` and deprecation warning message if the compiler looks like an MPI wrapper.

## Rationale for changes ##

More warnings to users about deprecated practice and fix unsupported/deprecated use case

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
