### PR TITLE
Bump GCC version that install.sh installs to 7.3.0

### DIFF
--- a/prerequisites/build-functions/set_or_print_default_version.sh
+++ b/prerequisites/build-functions/set_or_print_default_version.sh
@@ -27,7 +27,7 @@ set_or_print_default_version()
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_version=(
     "cmake:3.4.0"
-    "gcc:7.2.0"
+    "gcc:7.3.0"
     "mpich:3.2"
     "wget:1.16.3"
     "flex:2.6.0"


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Incremented the default GCC version that `./install.sh -p gcc` installs to 7.3.0.
## Rationale for changes ##

7.3.0 contains regression fixes for allocatable components of derived-type coarrays.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
