### PR TITLE
Adjust for new GCC 8 descriptor

### DIFF
--- a/src/libcaf-gfortran-descriptor.h
+++ b/src/libcaf-gfortran-descriptor.h
@@ -58,12 +58,24 @@ typedef struct gfc_descriptor_t {
 } gfc_descriptor_t;
 
 
-#define GFC_MAX_DIMENSIONS 7
+#ifdef GCC_GE_8
 
+#define GFC_MAX_DIMENSIONS 15
+#define GFC_DTYPE_RANK_MASK 0x0F
+#define GFC_DTYPE_TYPE_SHIFT 4
+#define GFC_DTYPE_TYPE_MASK 0x70
+#define GFC_DTYPE_SIZE_SHIFT 7
+
+#else
+
+#define GFC_MAX_DIMENSIONS 7
 #define GFC_DTYPE_RANK_MASK 0x07
 #define GFC_DTYPE_TYPE_SHIFT 3
 #define GFC_DTYPE_TYPE_MASK 0x38
 #define GFC_DTYPE_SIZE_SHIFT 6
+
+#endif
+
 #define GFC_DESCRIPTOR_RANK(desc) ((desc)->dtype & GFC_DTYPE_RANK_MASK)
 #define GFC_DESCRIPTOR_TYPE(desc) (((desc)->dtype & GFC_DTYPE_TYPE_MASK) \
                                    >> GFC_DTYPE_TYPE_SHIFT)


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Modified several C-preprocessor definitions in [libcaf-gfortran-descriptor.h](https://github.com/sourceryinstitute/OpenCoarrays/blob/master/src/libcaf-gfortran-descriptor.h).

## Rationale for changes ##

These changes adapt to the descriptor change that expands the
maximum (co)array dimension from 7 to 15 as applied to the GCC
trunk in svn revision 257065 (git commit [d9c7c3](https://github.com/gcc-mirror/gcc/commit/d9c7c3e3f6eb4621f929474e0ba44e7d61584431) on the GCC git
mirror).

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

@zbeekman This is not been fully tested.  I'll finish testing with GCC 8 later, but it should be safe to merge if the tests pass with GCC 6 and 7:

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code