### PR TITLE
Fix most warnings when compiling w/ clang

### DIFF
--- a/src/libcaf-gfortran-descriptor.h
+++ b/src/libcaf-gfortran-descriptor.h
@@ -104,7 +104,7 @@ typedef struct gfc_descriptor_t {
 #endif
 
 #define GFC_DTYPE_SIZE_MASK \
-  ((~((ptrdiff_t) 0) >> GFC_DTYPE_SIZE_SHIFT) << GFC_DTYPE_SIZE_SHIFT)
+  ( ~((ptrdiff_t)(1 << GFC_DTYPE_SIZE_SHIFT) - 1)) // least significant bits to 0
 #define GFC_DTYPE_TYPE_SIZE_MASK (GFC_DTYPE_SIZE_MASK | GFC_DTYPE_TYPE_MASK)
 
 #define GFC_DTYPE_INTEGER_1 ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT) \

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -6304,7 +6304,8 @@ PREFIX(is_present) (caf_token_t token, int image_index, caf_reference_t *refs)
               /* The first descriptor is accessible by the
               mpi_token->memptr_win.
               Count the dims to fetch.  */
-              for (ref_rank = 0; riter->u.a.mode[ref_rank] != CAF_ARR_REF_NONE; ++ref_rank) ;
+              for (ref_rank = 0; riter->u.a.mode[ref_rank] != CAF_ARR_REF_NONE; ++ref_rank)
+		;
               dprint ("%d/%d: %s() Getting remote descriptor of rank %d from win: %p, sizeof() %d\n",
                       caf_this_image, caf_num_images, __FUNCTION__,
                       ref_rank, mpi_token->memptr_win, sizeof_desc_for_rank(ref_rank));
@@ -6317,7 +6318,8 @@ PREFIX(is_present) (caf_token_t token, int image_index, caf_reference_t *refs)
             {
               /* All inner descriptors go by the dynamic window.
               Count the dims to fetch.  */
-              for (ref_rank = 0; riter->u.a.mode[ref_rank] != CAF_ARR_REF_NONE; ++ref_rank) ;
+              for (ref_rank = 0; riter->u.a.mode[ref_rank] != CAF_ARR_REF_NONE; ++ref_rank)
+		;
               dprint ("%d/%d: %s() Getting remote descriptor of rank %d from: %p, sizeof() %d\n",
                       caf_this_image, caf_num_images, __FUNCTION__,
                       ref_rank, remote_base_memptr, sizeof_desc_for_rank(ref_rank));


### PR DESCRIPTION
 - Issue with a type_def persists; non-constant member does not appear last

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Fixed most warnings/errors when compiling with Clang. Problematic struct (GNU extension) remains and requires more in-depth adjustment due to use of pointer arithmetic etc.

## Rationale for changes ##

Make code more standard conforming, and emit fewer warnings when building with clang

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
