### PR TITLE
Use ` `, not `;`, field sep when configuring `caf`

### DIFF
--- a/src/extensions/caf.in
+++ b/src/extensions/caf.in
@@ -50,8 +50,8 @@ set -o pipefail
 # List of variables needing configuration:
 #
 # CAF_VERSION, opencoarrays_aware_compiler, Fortran_COMPILER, CAF_MODDIR,
-# MPI_Fortran_LINK_FLAGS, MPI_Fortran_COMPILE_FLAGS,
-# CAF_LIBS, MPI_LIBS
+# CAF_MPI_Fortran_LINK_FLAGS, CAF_MPI_Fortran_COMPILE_FLAGS,
+# CAF_LIBS, CAF_MPI_LIBS
 #
 
 caf_version='@CAF_VERSION@' # fetched from `git describe` and/or
@@ -80,15 +80,15 @@ mod_dir_flag="-I"
 # variables expanded from CMake should be appropriately quoted.
 
 # shellcheck disable=SC2054
-mpi_link_flags=(@MPI_Fortran_LINK_FLAGS@) # e.g. `pkg-config
+mpi_link_flags=(@CAF_MPI_Fortran_LINK_FLAGS@) # e.g. `pkg-config
 # --libs-only-other mpich`
 # __*AND*__ `pkg-config
 # --libs-only-L`
-mpi_compile_flags=(@MPI_Fortran_COMPILE_FLAGS@)
+mpi_compile_flags=(@CAF_MPI_Fortran_COMPILE_FLAGS@)
 caf_libs=(@CAF_LIBS@) # e.g. "libcaf_mpi" "libcaf_extensions",
 # preferably full paths, but could be
 # combination of -L... and -lcaf_mpi...
-mpi_libs=(@MPI_LIBS@) # e.g. `pkg-config --libs-only-l` or full paths
+mpi_libs=(@CAF_MPI_LIBS@) # e.g. `pkg-config --libs-only-l` or full paths
 # to MPI libs
 
 #-------------------------

--- a/src/extensions/cafrun.in
+++ b/src/extensions/cafrun.in
@@ -68,10 +68,12 @@ if [[ ${numproc_flag} == @*@ ]]; then
   numproc_flag='-np'
 fi
 preflags="@MPIEXEC_PREFLAGS@"
+preflags="${preflags//;/ }"
 if [[ "${preflags}" == @*@ ]]; then
   unset preflags
 fi
 postflags="@MPIEXEC_POSTFLAGS@"
+postflags="${postflags//;/ }"
 if [[ "${postflags}" == @*@ ]]; then
   unset postflags
 fi

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -208,19 +208,29 @@ install(TARGETS caf_mpi_static EXPORT OpenCoarraysTargets
 # List of caf.in variables needing configuration:
 #
 # @CAF_VERSION@ @opencoarrays_aware_compiler@ @Fortran_COMPILER@ @CAF_MODDIR@
-# @MPI_Fortran_LINK_FLAGS@ @MPI_Fortran_COMPILE_FLAGS@
-# @CAF_LIBS@ @MPI_LIBS@
+# @CAF_MPI_Fortran_LINK_FLAGS@ @CAF_MPI_Fortran_COMPILE_FLAGS@
+# @CAF_LIBS@ @CAF_MPI_LIBS@
 #
 
 set(CAF_VERSION "${full_git_describe}")
 set(Fortran_COMPILER "${CMAKE_Fortran_COMPILER}")
 set(CAF_MODDIR "${CMAKE_INSTALL_INCLUDEDIR}/${mod_dir_tail}")
 set(MOD_DIR_FLAG "${CMAKE_Fortran_MODDIR_FLAG}")
-set(MPI_LIBS "")
+set(CAF_MPI_LIBS "")
 foreach( lib IN LISTS MPI_Fortran_LIBRARIES)
-  set(MPI_LIBS "${MPI_LIBS} \"${lib}\"")
+  set(CAF_MPI_LIBS "${CAF_MPI_LIBS} \"${lib}\"")
 endforeach()
 string(STRIP "${MPI_LIBS}" MPI_LIBS)
+set(CAF_MPI_Fortran_LINK_FLAGS "")
+foreach( lflag IN LISTS MPI_Fortran_LINK_FLAGS)
+  set(CAF_MPI_Fortran_LINK_FLAGS "${CAF_MPI_Fortran_LINK_FLAGS} ${lflag}" )
+endforeach()
+string(STRIP "${CAF_MPI_Fortran_LINK_FLAGS}" CAF_MPI_Fortran_LINK_FLAGS)
+set(CAF_MPI_Fortran_COMPILE_FLAGS "")
+foreach( fcflag IN LISTS MPI_Fortran_COMPILE_FLAGS)
+  set(CAF_MPI_Fortran_COMPILE_FLAGS "${CAF_MPI_Fortran_COMPILE_FLAGS} ${fcflag}" )
+endforeach()
+string(STRIP "${CAF_MPI_Fortran_COMPILE_FLAGS}" CAF_MPI_Fortran_COMPILE_FLAGS)
 set_target_properties(caf_mpi_static
   PROPERTIES OUTPUT_NAME caf_mpi)
 get_target_property(libcaf_static caf_mpi_static OUTPUT_NAME)


### PR DESCRIPTION
 CMake uses semi-colons to separate list items, and some of these
 semicolons were being injected into the `caf` script on some systems
 (FreeBSD) where as spaces should have been used. (See #475, specifically
 https://github.com/sourceryinstitute/OpenCoarrays/issues/475#issuecomment-364190210)

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Fix an issue in the `caf` script appearing on OpenBSD w/ OpenMPI2

## Rationale for changes ##

CMake was passing `;` as a field separator when configuring the `caf` script, but bash should use spaces for word splitting.

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
