### PR TITLE
Use size_t for character lengths with GFortran >= 8.x

### DIFF
--- a/src/libcaf-gfortran-descriptor.h
+++ b/src/libcaf-gfortran-descriptor.h
@@ -30,8 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 
 #include "libcaf-version-def.h"
 
-#include <stdint.h>	/* For int32_t.  */
-
 /* GNU Fortran's array descriptor.  Keep in sync with libgfortran.h.  To be
    replaced by TS29113's ISO_Fortran_binding.h with CFI_cdesc_t.  */
 

--- a/src/libcaf.h
+++ b/src/libcaf.h
@@ -28,7 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #ifndef LIBCAF_H
 #define LIBCAF_H
 
-#include <stdint.h>	/* For int32_t.  */
 #include <stddef.h>	/* For size_t.  */
 #include <stdbool.h>
 
@@ -213,10 +212,16 @@ typedef struct caf_reference_t {
 #define GFC_CAF_ARG_VALUE  (1<<2)
 #define GFC_CAF_ARG_DESC   (1<<3)
 
+/* The type to use for string lengths.  */
+#ifdef GCC_GE_8
+typedef size_t charlen_t;
+#else
+typedef int charlen_t;
+#endif
+
 /* Common auxiliary functions: caf_auxiliary.c.  */
 
 bool PREFIX (is_contiguous) (gfc_descriptor_t *);
-
 
 /* Header for the specific implementation.  */
 
@@ -228,8 +233,8 @@ int PREFIX (num_images) (int, int);
 
 #ifdef GCC_GE_7
 void PREFIX (register) (size_t, caf_register_t, caf_token_t *,
-						gfc_descriptor_t *, int *, char *, int);
-void PREFIX (deregister) (caf_token_t *, int, int *, char *, int);
+			gfc_descriptor_t *, int *, char *, charlen_t);
+void PREFIX (deregister) (caf_token_t *, int, int *, char *, charlen_t);
 #else
 void * PREFIX (register) (size_t, caf_register_t, caf_token_t *,
 						  int *, char *, int);
@@ -263,22 +268,22 @@ void PREFIX(sendget_by_ref) (caf_token_t dst_token, int dst_image_index,
 int PREFIX(is_present) (caf_token_t, int, caf_reference_t *refs);
 #endif
 
-void PREFIX (co_broadcast) (gfc_descriptor_t *, int, int *, char *, int);
-void PREFIX (co_max) (gfc_descriptor_t *, int, int *, char *, int, int);
-void PREFIX (co_min) (gfc_descriptor_t *, int, int *, char *, int, int);
+void PREFIX (co_broadcast) (gfc_descriptor_t *, int, int *, char *, charlen_t);
+void PREFIX (co_max) (gfc_descriptor_t *, int, int *, char *, int, charlen_t);
+void PREFIX (co_min) (gfc_descriptor_t *, int, int *, char *, int, charlen_t);
 void PREFIX (co_reduce) (gfc_descriptor_t *, void *(*opr) (void *, void *),
-			 int, int, int *, char *, int , int);
-void PREFIX (co_sum) (gfc_descriptor_t *, int, int *, char *, int);
+			 int, int, int *, char *, int , charlen_t);
+void PREFIX (co_sum) (gfc_descriptor_t *, int, int *, char *, charlen_t);
 
-void PREFIX (sync_all) (int *, char *, int);
-void PREFIX (sync_images) (int, int[], int *, char *, int);
-void PREFIX (sync_memory) (int *, char *, int);
+void PREFIX (sync_all) (int *, char *, charlen_t);
+void PREFIX (sync_images) (int, int[], int *, char *, charlen_t);
+void PREFIX (sync_memory) (int *, char *, charlen_t);
 
-void PREFIX (stop_str) (const char *, int32_t) __attribute__ ((noreturn));
-void PREFIX (stop) (int32_t) __attribute__ ((noreturn));
-void PREFIX (error_stop_str) (const char *, int32_t)
+void PREFIX (stop_str) (const char *, charlen_t) __attribute__ ((noreturn));
+void PREFIX (stop) (int) __attribute__ ((noreturn));
+void PREFIX (error_stop_str) (const char *, charlen_t)
      __attribute__ ((noreturn));
-void PREFIX (error_stop) (int32_t) __attribute__ ((noreturn));
+void PREFIX (error_stop) (int) __attribute__ ((noreturn));
 void PREFIX (fail_image) (void) __attribute__ ((noreturn));
 
 void PREFIX (form_team) (int, caf_team_t *, int);
@@ -298,10 +303,10 @@ void PREFIX (atomic_cas) (caf_token_t, size_t, int, void *, void *,
 void PREFIX (atomic_op) (int, caf_token_t, size_t, int, void *, void *,
 			 int *, int, int);
 
-void PREFIX (lock) (caf_token_t, size_t, int, int *, int *, char *, int);
-void PREFIX (unlock) (caf_token_t, size_t, int, int *, char *, int);
-void PREFIX (event_post) (caf_token_t, size_t, int, int *, char *, int);
-void PREFIX (event_wait) (caf_token_t, size_t, int, int *, char *, int);
+void PREFIX (lock) (caf_token_t, size_t, int, int *, int *, char *, charlen_t);
+void PREFIX (unlock) (caf_token_t, size_t, int, int *, char *, charlen_t);
+void PREFIX (event_post) (caf_token_t, size_t, int, int *, char *, charlen_t);
+void PREFIX (event_wait) (caf_token_t, size_t, int, int *, char *, charlen_t);
 void PREFIX (event_query) (caf_token_t, size_t, int, int *, int *);
 
 /* Language extension */

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -42,6 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #include <alloca.h>        /* Assume functionality provided elsewhere if missing */
 #endif
 #include <unistd.h>
+#include <stdint.h>	/* For int32_t.  */
 #include <mpi.h>
 #include <pthread.h>
 #include <signal.h>        /* For raise */
@@ -146,7 +147,7 @@ typedef MPI_Win *mpi_caf_token_t;
 static void terminate_internal (int stat_code, int exit_code)
             __attribute__ ((noreturn));
 static void sync_images_internal (int count, int images[], int *stat,
-                                  char *errmsg, int errmsg_len, bool internal);
+                                  char *errmsg, size_t errmsg_len, bool internal);
 
 /* Global variables.  */
 static int caf_this_image;
@@ -602,7 +603,7 @@ redo:
 #endif
 
 void mutex_lock(MPI_Win win, int image_index, int index, int *stat,
-		int *acquired_lock, char *errmsg, int errmsg_len)
+		int *acquired_lock, char *errmsg, size_t errmsg_len)
 {
   const char msg[] = "Already locked";
 #if MPI_VERSION >= 3
@@ -683,7 +684,7 @@ stat_error:
 }
 
 void mutex_unlock(MPI_Win win, int image_index, int index, int *stat,
-		  char* errmsg, int errmsg_len)
+		  char* errmsg, size_t errmsg_len)
 {
   const char msg[] = "Variable is not locked";
   if(stat != NULL)
@@ -1051,7 +1052,7 @@ PREFIX (num_images) (int distance __attribute__ ((unused)),
 void
 PREFIX (register) (size_t size, caf_register_t type, caf_token_t *token,
                    gfc_descriptor_t *desc, int *stat, char *errmsg,
-		   int errmsg_len)
+		   charlen_t errmsg_len)
 {
   /* int ierr; */
   void *mem = NULL;
@@ -1202,10 +1203,10 @@ error:
         *stat = caf_is_finalized ? STAT_STOPPED_IMAGE : 1;
         if (errmsg_len > 0)
           {
-            int len = ((int) strlen (msg) > errmsg_len) ? errmsg_len
-                                                        : (int) strlen (msg);
+            size_t len = (strlen (msg) > (size_t) errmsg_len) ? (size_t) errmsg_len
+                                                        : strlen (msg);
             memcpy (errmsg, msg, len);
-            if (errmsg_len > len)
+            if ((size_t) errmsg_len > len)
               memset (&errmsg[len], ' ', errmsg_len-len);
           }
       }
@@ -1216,7 +1217,7 @@ error:
 #else // GCC_GE_7
 void *
 PREFIX (register) (size_t size, caf_register_t type, caf_token_t *token,
-                   int *stat, char *errmsg, int errmsg_len)
+                   int *stat, char *errmsg, charlen_t errmsg_len)
 {
   /* int ierr; */
   void *mem;
@@ -1291,8 +1292,8 @@ error:
         *stat = caf_is_finalized ? STAT_STOPPED_IMAGE : 1;
         if (errmsg_len > 0)
           {
-            int len = ((int) strlen (msg) > errmsg_len) ? errmsg_len
-                                                        : (int) strlen (msg);
+            size_t len = (strlen (msg) > (size_t) errmsg_len) ? (size_t) errmsg_len
+                                                        : strlen (msg);
             memcpy (errmsg, msg, len);
             if (errmsg_len > len)
               memset (&errmsg[len], ' ', errmsg_len-len);
@@ -1309,10 +1310,10 @@ error:
 #ifdef GCC_GE_7
 void
 PREFIX (deregister) (caf_token_t *token, int type, int *stat, char *errmsg,
-		     int errmsg_len)
+		     charlen_t errmsg_len)
 #else
 void
-PREFIX (deregister) (caf_token_t *token, int *stat, char *errmsg, int errmsg_len)
+PREFIX (deregister) (caf_token_t *token, int *stat, char *errmsg, charlen_t errmsg_len)
 #endif
 {
   dprint ("%d/%d: deregister(%p)\n", caf_this_image, caf_num_images, *token);
@@ -1327,8 +1328,8 @@ PREFIX (deregister) (caf_token_t *token, int *stat, char *errmsg, int errmsg_len
 
           if (errmsg_len > 0)
             {
-              int len = ((int) sizeof (msg) - 1 > errmsg_len)
-                        ? errmsg_len : (int) sizeof (msg) - 1;
+              size_t len = (sizeof (msg) - 1 > (size_t) errmsg_len)
+		? (size_t) errmsg_len : sizeof (msg) - 1;
               memcpy (errmsg, msg, len);
               if (errmsg_len > len)
                 memset (&errmsg[len], ' ', errmsg_len-len);
@@ -1451,7 +1452,7 @@ PREFIX (deregister) (caf_token_t *token, int *stat, char *errmsg, int errmsg_len
 void
 PREFIX (sync_memory) (int *stat __attribute__ ((unused)),
                       char *errmsg __attribute__ ((unused)),
-                      int errmsg_len __attribute__ ((unused)))
+                      charlen_t errmsg_len __attribute__ ((unused)))
 {
 #if defined(NONBLOCKING_PUT) && !defined(CAF_MPI_LOCK_UNLOCK)
   explicit_flush ();
@@ -1460,7 +1461,7 @@ PREFIX (sync_memory) (int *stat __attribute__ ((unused)),
 
 
 void
-PREFIX (sync_all) (int *stat, char *errmsg, int errmsg_len)
+PREFIX (sync_all) (int *stat, char *errmsg, charlen_t errmsg_len)
 {
   int ierr = 0;
 
@@ -1505,8 +1506,8 @@ PREFIX (sync_all) (int *stat, char *errmsg, int errmsg_len)
 
       if (errmsg_len > 0)
         {
-          int len = ((int) strlen (msg) > errmsg_len) ? errmsg_len
-                                                      : (int) strlen (msg);
+          size_t len = (strlen (msg) > (size_t) errmsg_len) ? (size_t) errmsg_len
+	    : strlen (msg);
           memcpy (errmsg, msg, len);
           if (errmsg_len > len)
             memset (&errmsg[len], ' ', errmsg_len-len);
@@ -6414,14 +6415,14 @@ PREFIX(is_present) (caf_token_t token, int image_index, caf_reference_t *refs)
 
 void
 PREFIX (sync_images) (int count, int images[], int *stat, char *errmsg,
-                     int errmsg_len)
+		      charlen_t errmsg_len)
 {
   sync_images_internal (count, images, stat, errmsg, errmsg_len, false);
 }
 
 static void
 sync_images_internal (int count, int images[], int *stat, char *errmsg,
-                      int errmsg_len, bool internal)
+                      size_t errmsg_len, bool internal)
 {
   int ierr = 0, i = 0, j = 0, int_zero = 0, done_count = 0;
   MPI_Status s;
@@ -6574,8 +6575,8 @@ sync_images_err_chk:
 
       if (errmsg_len > 0)
         {
-          int len = ((int) strlen (msg) > errmsg_len) ? errmsg_len
-                                                      : (int) strlen (msg);
+          size_t len = (strlen (msg) > errmsg_len) ? errmsg_len
+	    : strlen (msg);
           memcpy (errmsg, msg, len);
           if (errmsg_len > len)
             memset (&errmsg[len], ' ', errmsg_len-len);
@@ -6770,7 +6771,7 @@ get_MPI_datatype (gfc_descriptor_t *desc, int char_len)
 
 static void
 internal_co_reduce (MPI_Op op, gfc_descriptor_t *source, int result_image, int *stat,
-	     char *errmsg, int src_len, int errmsg_len)
+	     char *errmsg, int src_len, size_t errmsg_len)
 {
   size_t i, size;
   int j, ierr;
@@ -6863,7 +6864,7 @@ error:
 
 void
 PREFIX (co_broadcast) (gfc_descriptor_t *a, int source_image, int *stat, char *errmsg,
-                       int errmsg_len)
+                       charlen_t errmsg_len)
 {
   size_t i, size;
   int j, ierr;
@@ -6963,7 +6964,7 @@ error:
  * for use in MPI_*Reduce functions. */
 void
 PREFIX (co_reduce) (gfc_descriptor_t *a, void *(*opr) (void *, void *), int opr_flags,
-		    int result_image, int *stat, char *errmsg, int a_len, int errmsg_len)
+		    int result_image, int *stat, char *errmsg, int a_len, charlen_t errmsg_len)
 {
   MPI_Op op;
   /* Integers and logicals can be treated the same. */
@@ -7033,7 +7034,7 @@ PREFIX (co_reduce) (gfc_descriptor_t *a, void *(*opr) (void *, void *), int opr_
 
 void
 PREFIX (co_sum) (gfc_descriptor_t *a, int result_image, int *stat, char *errmsg,
-                 int errmsg_len)
+                 charlen_t errmsg_len)
 {
   internal_co_reduce (MPI_SUM, a, result_image, stat, errmsg, 0, errmsg_len);
 }
@@ -7041,7 +7042,7 @@ PREFIX (co_sum) (gfc_descriptor_t *a, int result_image, int *stat, char *errmsg,
 
 void
 PREFIX (co_min) (gfc_descriptor_t *a, int result_image, int *stat, char *errmsg,
-                 int src_len, int errmsg_len)
+                 int src_len, charlen_t errmsg_len)
 {
   internal_co_reduce (MPI_MIN, a, result_image, stat, errmsg, src_len, errmsg_len);
 }
@@ -7049,7 +7050,7 @@ PREFIX (co_min) (gfc_descriptor_t *a, int result_image, int *stat, char *errmsg,
 
 void
 PREFIX (co_max) (gfc_descriptor_t *a, int result_image, int *stat,
-                 char *errmsg, int src_len, int errmsg_len)
+                 char *errmsg, int src_len, charlen_t errmsg_len)
 {
   internal_co_reduce (MPI_MAX, a, result_image, stat, errmsg, src_len, errmsg_len);
 }
@@ -7060,7 +7061,7 @@ PREFIX (co_max) (gfc_descriptor_t *a, int result_image, int *stat,
 void
 PREFIX (lock) (caf_token_t token, size_t index, int image_index,
                int *acquired_lock, int *stat, char *errmsg,
-               int errmsg_len)
+               charlen_t errmsg_len)
 {
   int dest_img;
   MPI_Win *p = TOKEN(token);
@@ -7076,7 +7077,7 @@ PREFIX (lock) (caf_token_t token, size_t index, int image_index,
 
 void
 PREFIX (unlock) (caf_token_t token, size_t index, int image_index,
-                 int *stat, char *errmsg, int errmsg_len)
+                 int *stat, char *errmsg, charlen_t errmsg_len)
 {
   int dest_img;
   MPI_Win *p = TOKEN(token);
@@ -7260,7 +7261,7 @@ PREFIX (atomic_op) (int op, caf_token_t token ,
 void
 PREFIX (event_post) (caf_token_t token, size_t index,
 		     int image_index, int *stat,
-		     char *errmsg, int errmsg_len)
+		     char *errmsg, charlen_t errmsg_len)
 {
   int image, value = 1, ierr = 0,flag;
   MPI_Win *p = TOKEN(token);
@@ -7303,7 +7304,7 @@ PREFIX (event_post) (caf_token_t token, size_t index,
 void
 PREFIX (event_wait) (caf_token_t token, size_t index,
 		     int until_count, int *stat,
-		     char *errmsg, int errmsg_len)
+		     char *errmsg, charlen_t errmsg_len)
 {
   int ierr = 0, count = 0, i, image = caf_this_image - 1;
   int *var = NULL, flag, old = 0;
@@ -7407,7 +7408,7 @@ terminate_internal (int stat_code, int exit_code)
 /* STOP function for integer arguments.  */
 
 void
-PREFIX (stop_numeric) (int32_t stop_code)
+PREFIX (stop_numeric) (int stop_code)
 {
   fprintf (stderr, "STOP %d\n", stop_code);
 
@@ -7420,7 +7421,7 @@ PREFIX (stop_numeric) (int32_t stop_code)
 /* STOP function for string arguments.  */
 
 void
-PREFIX (stop_str) (const char *string, int32_t len)
+PREFIX (stop_str) (const char *string, charlen_t len)
 {
   fputs ("STOP ", stderr);
   while (len--)
@@ -7435,7 +7436,7 @@ PREFIX (stop_str) (const char *string, int32_t len)
 /* ERROR STOP function for string arguments.  */
 
 void
-PREFIX (error_stop_str) (const char *string, int32_t len)
+PREFIX (error_stop_str) (const char *string, charlen_t len)
 {
   fputs ("ERROR STOP ", stderr);
   while (len--)
@@ -7449,7 +7450,7 @@ PREFIX (error_stop_str) (const char *string, int32_t len)
 /* ERROR STOP function for numerical arguments.  */
 
 void
-PREFIX (error_stop) (int32_t error)
+PREFIX (error_stop) (int error)
 {
   fprintf (stderr, "ERROR STOP %d\n", error);
 


### PR DESCRIPTION
GFortran 8.x uses size_t for character lengths instead of int. This
patch applies the same changes to OpenCoarrays. Also, the STOP and
ERROR STOP routines now take a plain int for the numeric exit code.

This fixes
https://github.com/sourceryinstitute/OpenCoarrays/issues/497.

This pull request (PR) is a:

- [ ] Bug fix
- [ ] Feature addition
- [x] Other, Please describe:

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
