### PR TITLE
Debug config fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ os: osx
 env:
   global:
     - CACHE="${HOME}/.local"
-    - MPICH_VER="3.2"
+    - MPICH_VER="3.2.1"
     - MPICH_URL_HEAD="https://www.mpich.org/static/downloads/${MPICH_VER}"
     - MPICH_URL_TAIL="mpich-${MPICH_VER}.tar.gz"
-    - MPICH_GCC6_BOT_URL_HEAD="https://github.com/sourceryinstitute/OpenCoarrays/files/979804/"
-    - MPICH_GCC7_BOT_URL_HEAD="https://github.com/sourceryinstitute/OpenCoarrays/files/976779/"
-    - MPICH_BOT_URL_TAIL="mpich-3.2_3.yosemite.bottle.1.tar.gz"
+    - MPICH_GCC6_BOT_URL_HEAD="https://github.com/sourceryinstitute/OpenCoarrays/files/1956499/"
+    - MPICH_GCC7_BOT_URL_HEAD="https://github.com/sourceryinstitute/OpenCoarrays/files/1956441/"
+    - MPICH_BOT_URL_TAIL="mpich-3.2.1_1.high_sierra.bottle.1.tar.gz"
     - BUILD_TYPES="Release Debug RelWithDebInfo CodeCoverage"
   matrix:
     - GCC=6 OSX_PACKAGES="gcc@6 shellcheck" BUILD_TYPE="InstallScript"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,10 @@ the C compiler if it matches the Fortran compiler ID." )
   set( CMAKE_Fortran_COMPILER_VERSION "${DETECTED_VER}" )
 endif()
 
+if(CMAKE_BUILD_TYPE MATCHES "Debug|DEBUG|debug")
+  add_definitions(-DEXTRA_DEBUG_OUTPUT)
+endif()
+
   # We have populated CMAKE_Fortran_COMPILER_VERSION if it was missing
   if(gfortran_compiler AND (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 5.0.0))
     set(opencoarrays_aware_compiler true)

--- a/developer-scripts/travis/install.linux.sh
+++ b/developer-scripts/travis/install.linux.sh
@@ -25,16 +25,21 @@ if [[ "${BUILD_TYPE:-}" != InstallScript ]]; then # Ubuntu on Travis-CI, NOT tes
     if ! [[ -x "${HOME}/.local/bin/mpif90" && -x "${HOME}/.local/bin/mpicc" ]]; then
         # mpich install not cached
         # could use prerequisites/build instead...
-        wget "${MPICH_URL_HEAD}/${MPICH_URL_TAIL}"
-        tar -xzvf "${MPICH_URL_TAIL}"
-	export CC=gcc-${GCC}
-	export FC=gfortran-${GCC}
+        echo "Downloading MPICH from ${MPICH_URL_HEAD}/${MPICH_URL_TAIL} ..."
+        wget "${MPICH_URL_HEAD}/${MPICH_URL_TAIL}" > wget_mpich.log 2>&1 || cat wget_mpich.log
+        echo "Extracting MPICH ..."
+        tar -xzvf "${MPICH_URL_TAIL}" > tar_mpich.log 2>&1 || cat tar_mpich.log
+        export CC=gcc-${GCC}
+        export FC=gfortran-${GCC}
         (
-	    cd "${MPICH_URL_TAIL%.tar.gz}"
-            ./configure --prefix="${CACHE}"
-            make -j 4
-            make install
-	)
+            cd "${MPICH_URL_TAIL%.tar.gz}"
+            echo "Configuring MPICH ..."
+            ${TRAVIS:+travis_wait} ./configure --prefix="${CACHE}" > configure_mpich.log 2>&1 || cat configure_mpich.log
+            echo "Building MPICH ..."
+            ${TRAVIS:+travis_wait 30} make -j 4 > make_mpich.log 2>&1 || cat make_mpich.log
+            echo "Installing MPICH ..."
+            ${TRAVIS:+travis_wait} make install > install_mpich.log 2>&1 || cat install_mpich.log
+        )
     fi
 fi
 

--- a/developer-scripts/travis/test-script.cmake.sh
+++ b/developer-scripts/travis/test-script.cmake.sh
@@ -33,7 +33,8 @@ for version in ${GCC}; do
 	# but puting it here simplifies the Travis code a lot
 	MPICH_BOT_URL_HEAD=MPICH_GCC${version}_BOT_URL_HEAD
 	brew uninstall --force --ignore-dependencies mpich || true
-	wget "${!MPICH_BOT_URL_HEAD}${MPICH_BOT_URL_TAIL}"
+	echo "Downloading Custom MPICH bottle ${!MPICH_BOT_URL_HEAD}${MPICH_BOT_URL_TAIL} ..."
+	wget "${!MPICH_BOT_URL_HEAD}${MPICH_BOT_URL_TAIL}" > wget_mpichbottle.log 2>&1 || cat wget_mpichbottle.log
 	brew install --force-bottle "${MPICH_BOT_URL_TAIL}"
 	brew ls --versions mpich >/dev/null || brew install --force-bottle mpich
 	rm "${MPICH_BOT_URL_TAIL}"


### PR DESCRIPTION
<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

@rouson a speedy review would be most welcome so I can merge this.

## Summary of changes ##

- Added define for debugging with debug configuration `-DEXTRA_DEBUG_OUTPUT`. This may cause Travis-CI failures if too much data is printed.
- Silenced some basic wget and configure/make for prerequisite packages unless they fail on Travis-CI
- Updated the MPICH Homebrew bottles since Homebrew has been upgraded to change `depend_on => :fortran` to be `depends_on => "gcc"` which was causing CI failures because Homebrew was throwing errors for the old bottled MPICH formulae.


## Rationale for changes ##

- Fix failing macOS CI tests (update MPICH bottle due to Homebrew changes) because OpenCoarrays is still passing and CI should function correctly
- Make CI output easier to read by not printing `wget`/`curl` output unless an error is encountered.

## Additional info and certifications ##

This pull request (PR) is a:

- [ ] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [ ] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
