### PR TITLE
Fix 2nd place where installer checks compiler ver.

### DIFF
--- a/prerequisites/install-functions/find_or_install.sh
+++ b/prerequisites/install-functions/find_or_install.sh
@@ -173,11 +173,11 @@ find_or_install()
 
         else
 
-          info "$this_script: Checking whether $executable in PATH wraps gfortran version >= $(./build.sh -V gcc)... "
+          info "$this_script: Checking whether $executable in PATH wraps gfortran version >= $minimum_version... "
           $executable acceptable_compiler.f90 -o acceptable_compiler || true;
           $executable print_true.f90 -o print_true || true;
           if [[ -f ./acceptable_compiler && -f ./print_true ]]; then
-            acceptable=$(./acceptable_compiler)
+            acceptable=$(./acceptable_compiler $minimum_version)
             is_true=$(./print_true)
             rm acceptable_compiler print_true
           else
@@ -273,13 +273,14 @@ find_or_install()
       stack_push dependency_path "none"
 
     elif [[ "$package_in_path" == "true" ]]; then
-      export minimum_acceptable_version=$(./build.sh -V gcc)
-      info "$this_script: Checking whether $executable in PATH is version $minimum_acceptable_version or later..."
+      info "$this_script: Checking whether $executable in PATH is version $minimum_version or later..."
       $executable -o acceptable_compiler acceptable_compiler.f90 || true;
       $executable -o print_true print_true.f90 || true;
       if [[ -f ./acceptable_compiler && -f ./print_true ]]; then
         is_true=$(./print_true)
-        acceptable=$(./acceptable_compiler $minimum_acceptable_version)
+        emergency "Executing `./acceptable_compiler $minimum_version`"
+        ./acceptable_compiler $minimum_version
+        acceptable=$(./acceptable_compiler $minimum_version)
         rm acceptable_compiler print_true
       else
         acceptable=false
@@ -675,6 +676,6 @@ find_or_install()
         else
           export PATH="$package_install_prefix/bin:$PATH"
         fi
-      fi 
+      fi
     fi # End 'if [[ ! -x "$package_install_prefix/bin/$executable" ]]; then'
 }


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Update `prerequisites/install-functions/find_or_install.sh` so that the 2nd place where the compiler version is checked now passes the new argument expected by `acceptable_compiler.f90`.

## Rationale for changes ##

Invoking `./install.sh` with no arguments traverses a previously untested branch through the above script.  That branch's invocation of the executable program `acceptable_compiler` lacked the new argument that was added to that program in the most recently merged pull request.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code