### PR TITLE
Switch insecure ftp URLs to secure https

### DIFF
--- a/prerequisites/build-functions/set_or_print_url.sh
+++ b/prerequisites/build-functions/set_or_print_url.sh
@@ -21,20 +21,20 @@ else
     major_minor="${version_to_build%.*}"
   elif [[ "${package_to_build}" == "gcc" ]]; then
     if [[ -z "${arg_b:-${arg_B}}" ]]; then
-      gcc_url_head="ftp://ftp.gnu.org:/gnu/gcc/gcc-${version_to_build}/"
+      gcc_url_head="https://ftpmirror.gnu.org/gcc/gcc-${version_to_build}/gcc-${version_to_build}.tar.xz/"
     else
       gcc_url_head="svn://gcc.gnu.org/svn/gcc/"
     fi
   fi
   package_url_head=(
     "gcc;${gcc_url_head-}"
-    "wget;ftp://ftp.gnu.org:/gnu/wget/"
-    "m4;ftp://ftp.gnu.org:/gnu/m4/"
+    "wget;https://ftpmirror.gnu.org/gnu/wget/"
+    "m4;https://ftpmirror.gnu.org/gnu/m4/"
     "pkg-config;https://pkgconfig.freedesktop.org/releases/"
     "mpich;https://www.mpich.org/static/downloads/${version_to_build-}/"
     "flex;https://sourceforge.net/projects/flex/files/"
-    "make;ftp://ftp.gnu.org/gnu/make/"
-    "bison;ftp://ftp.gnu.org:/gnu/bison/"
+    "make;https://ftpmirror.gnu.org/gnu/make/"
+    "bison;https://ftpmirror.gnu.org/gnu/bison/"
     "cmake;https://www.cmake.org/files/v${major_minor:-}/"
     "subversion;https://www.eu.apache.org/dist/subversion/"
   )


### PR DESCRIPTION
Each download has been tested using the -o download-only option such as
```
./install.sh -p gcc -o
```
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Changed all prerequisite package `ftp` URLs to `https` mirror-site equivalents.

## Rationale for changes ##

See issue #585.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code