### PR TITLE
Issue 586 deprecated mpi func

### DIFF
--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -210,7 +210,7 @@ foreach(symbol ${NEEDED_SYMBOLS})
   CHECK_SYMBOL_EXISTS(${symbol} "${MPI_HEADERS}" HAVE_${symbol})
   if(NOT HAVE_${symbol})
     message( STATUS "\${HAVE_${symbol}} = ${HAVE_${symbol}}")
-    message( WARNING
+    message( STATUS
       "Note: Failed Images not supported by the current MPI implementation! (Needs MPIX experimental features--as of MPI3)")
     set(MPI_HAS_FAULT_TOL_EXT NO)
     break() # no need to keep looking

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -6989,8 +6989,8 @@ static void
 redux_char_by_reference_adapter(void *invec, void *inoutvec, int *len,
                                 MPI_Datatype *datatype)
 {
-  MPI_Aint string_len;
-  MPI_Type_extent(*datatype, &string_len);
+  MPI_Aint lb, string_len;
+  MPI_Type_get_extent(*datatype, &lb, &string_len);
   for (int i = 0; i < *len; i++)
   {
     /* The length of the result is fixed, i.e., no deferred string length is

--- a/src/openshmem/openshmem_caf.c
+++ b/src/openshmem/openshmem_caf.c
@@ -3094,8 +3094,8 @@ static void \
 redux_char_by_reference_adapter (void *invec, void *inoutvec, int *len,
       MPI_Datatype *datatype)
 {
-  long int string_len;
-  MPI_Type_extent(*datatype, &string_len);
+  long int lb, string_len; // this should be MPI_Aint
+  MPI_Type_extent(*datatype, &lb, &string_len);
   for(int i = 0; i < *len; i++)
     {
       /* The length of the result is fixed, i.e., no deferred string length is


### PR DESCRIPTION
<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

`MPI_Type_extent()` --> `MPI_Type_get_extent()`

## Rationale for changes ##

The `MPI_Type_extent()` function is deprecated, and the build fails with newer MPI.

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix (#586)
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
