### PR TITLE
[WIP] Support ULFM2

### DIFF
--- a/src/extensions/cafrun.in
+++ b/src/extensions/cafrun.in
@@ -156,13 +156,15 @@ usage() {
   echo "   --wraps, -w,             Report info about the wrapped MPI launcher"
   echo "   -np <N>,                 Number of images, N, to execute, N must be a positive integer"
   echo "   -n <N>,                  Same as -np"
-  echo "   --reenable-auto-cleanup  Turn off failed images support (if library support is present)"
-  echo "                            This option re-enables MPI auto cleanup, which is disabled by"
-  echo "                            by default if GFortran/OpenCoarrays/MPI all support failed"
-  echo "                            images through MPI ULFM. When MPI auto cleanup is disabled and"
-  echo "                            failed image support is present, OpenCoarrays triggers cleanup"
-  echo "                            explicitly when a failed/stopped image is encountered in an"
-  echo "                            image control statement without a \`stat=\` clause."
+  if [[ ${have_failed_img} != 'false' ]]; then
+    echo "   --disable-failed-images  Turn off failed images support (if library support is present)"
+    echo "                            This option re-enables MPI auto cleanup, which is disabled by"
+    echo "                            by default if GFortran/OpenCoarrays/MPI all support failed"
+    echo "                            images through MPI ULFM. When MPI auto cleanup is disabled and"
+    echo "                            failed image support is present, OpenCoarrays triggers cleanup"
+    echo "                            explicitly when a failed/stopped image is encountered in an"
+    echo "                            image control statement without a \`stat=\` clause."
+  fi
   echo "   --show, -s,              Show the command that the wrapper will execute. You can pass"
   echo "                            this as the first argument and then the additional arguments"
   echo "                            that you're planning to pass to perform a dry run."
@@ -175,7 +177,9 @@ usage() {
   echo "   ${cmd} --help"
   echo "   ${cmd} --show"
   echo "   ${cmd} -s -np 4 my_exe"
-  echo "   ${cmd} -np 4 --reenable-auto-cleanup ./my_exe arg1 arg2"
+  if [[ ${have_failed_img} != 'false' ]]; then
+    echo "   ${cmd} -np 4 --disable-failed-images ./my_exe arg1 arg2"
+  fi
   echo ""
   echo " Notes:"
   echo "   [options] must be a CAF executable file, one of the above arguments,"
@@ -187,25 +191,32 @@ i=0
 disable_failed_images=false
 for arg in "${@}"; do
   ((i+=1))
-  if [[ "${arg}" == "--reenable-auto-cleanup" ]]; then
+  if [[ "${arg}" == "--disable-failed-images" ]]; then
     # Strip "--reenable-auto-cleanup" from args
     set -- "${@:1:$((i - 1))}" "${@:$((i+1)):$((${#} - i))}"
-    if ! ${have_failed_img}; then
-      echo "Library was not built with failed image support, so passing \`--reenable-auto-cleanup\` is a noop" >&2
+    if [[ ${have_failed_img} == 'false' ]]; then
+      echo "Library was not built with failed image support, so passing \`--disable-failed-images\` is a noop" >&2
     fi
     disable_failed_images=true
   fi
 done
 
 if ! ${disable_failed_images}; then
-  if ${have_failed_img}; then
+  if [[ ${have_failed_img} == 'mpich' ]]; then
     if [[ -n "${preflags:-}" ]]; then
       preflags+=(--disable-auto-cleanup)
     else
       preflags=(--disable-auto-cleanup)
     fi
   fi
+elif [[ ${have_failed_img} == 'ulfm2' ]]; then
+  if [[ -n "${preflags:-}" ]]; then
+    preflags+=(--disable-recovery)
+  else
+    preflags=(--disable-recovery)
+  fi
 fi
+
 
 # Print useage information if caf is invoked without arguments
 if ((${#} == 0)); then

--- a/src/extensions/cafrun.in
+++ b/src/extensions/cafrun.in
@@ -208,8 +208,14 @@ if ! ${disable_failed_images}; then
     else
       preflags=(--disable-auto-cleanup)
     fi
+  elif [[ ${have_failed_img} == 'openmpi' ]]; then
+    if [[ -n "${preflags:-}" ]]; then
+      preflags+=(--enable-recovery)
+    else
+      preflags=(--enable-recovery)
+    fi
   fi
-elif [[ ${have_failed_img} == 'ulfm2' ]]; then
+elif [[ ${have_failed_img} == 'openmpi' ]]; then
   if [[ -n "${preflags:-}" ]]; then
     preflags+=(--disable-recovery)
   else

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -120,6 +120,7 @@ execute_process(COMMAND ${MPIEXEC} --version
 if (mpi_version_out MATCHES "[Oo]pen[ -][Mm][Pp][Ii]")
   message( STATUS "OpenMPI detected")
   set ( openmpi true PARENT_SCOPE)
+  set ( openmpi true )
   # Write out a host file because OMPI's mpiexec is dumb
   file(WRITE ${CMAKE_BINARY_DIR}/hostfile "${HOST_NAME} slots=${N_CPU}\n")
   message( STATUS "hostfile written to: ${CMAKE_BINARY_DIR}/hostfile")
@@ -321,7 +322,11 @@ configure_file("${CMAKE_SOURCE_DIR}/src/extensions/caf.in" "${CMAKE_BINARY_DIR}/
 #
 
 if(CAF_ENABLE_FAILED_IMAGES)
-  set(HAVE_FAILED_IMG "true")
+  if (openmpi) # in cafrun, distinguish mpiexec arguments to enable/disable failed images
+    set(HAVE_FAILED_IMG "ulfm2")
+  else()
+    set(HAVE_FAILED_IMG "mpich")
+  endif()
 else()
   set(HAVE_FAILED_IMG "false")
 endif()

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -235,7 +235,7 @@ set(CMAKE_REQUIRED_INCLUDES ${old_cmake_required_includes})
 set(CMAKE_REQUIRED_FLAGS ${old_cmake_required_flags})
 set(CMAKE_REQUIRED_LIBRARIES ${old_cmake_required_libraries})
 
-if(MPI_HAS_FAULT_TOL_EXT) # AND (NOT openmpi))
+if(MPI_HAS_FAULT_TOL_EXT)
   option(CAF_ENABLE_FAILED_IMAGES "Enable failed images support" FALSE)
   message(STATUS "The MPI implementation appears to have the experimental features for ULFM
 that will allow you to build OpenCoarrays with failed images support. However,
@@ -323,7 +323,7 @@ configure_file("${CMAKE_SOURCE_DIR}/src/extensions/caf.in" "${CMAKE_BINARY_DIR}/
 
 if(CAF_ENABLE_FAILED_IMAGES)
   if (openmpi) # in cafrun, distinguish mpiexec arguments to enable/disable failed images
-    set(HAVE_FAILED_IMG "ulfm2")
+    set(HAVE_FAILED_IMG "openmpi")
   else()
     set(HAVE_FAILED_IMG "mpich")
   endif()

--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -1009,8 +1009,8 @@ finalize_internal(int status_code)
   if (status_code == 0)
   {
     /* In finalization do not report stopped or failed images any more. */
-    ierr = MPI_Errhandler_set(CAF_COMM_WORLD, MPI_ERRORS_RETURN); chk_err(ierr);
-    ierr = MPI_Errhandler_set(alive_comm, MPI_ERRORS_RETURN); chk_err(ierr);
+    ierr = MPI_Comm_set_errhandler(CAF_COMM_WORLD, MPI_ERRORS_RETURN); chk_err(ierr);
+    ierr = MPI_Comm_set_errhandler(alive_comm, MPI_ERRORS_RETURN); chk_err(ierr);
     /* Only add a conventional barrier to prevent images rom quitting too
      * early, when this images is not failing. */
     dprint("Before MPI_Barrier(CAF_COMM_WORLD)\n");


### PR DESCRIPTION
## Summary of Changes ##

Preliminary [ULFM2](https://bitbucket.org/icldistcomp/ulfm2) support when OpenCoarrays is configured with -DCAF_ENABLE_FAILED_IMAGES=TRUE.

* Enable building OpenCoarrays with ULFM2 by replacing the deprecated `MPI_Errhandler_set()` with `MPI_Comm_set_errhandler()`, as Open-MPI (which ULFM2 is forked from) doesn't support the former by default (only if configured with `--enable-mpi1-compatibility`).
* Support the ULFM2 mpiexec in cafrun by not adding `--disable-auto-cleanup` to the mpiexec command argument list. This pull request suggests changing the MPICH-specific `--reenable-auto-cleanup` option to the self-descriptive `--disable-failed-images`, and internally adding `--disable-recovery` to the mpiexec argument list if using ULFM2, else `--reenable-auto-cleanup`.

Note that not all of the regression tests pass; in particular, the failed images tests seem to fail due to a problem with ULFM2 + an MPI thread level > MPI_THREAD_SINGLE (https://bitbucket.org/icldistcomp/ulfm2/issues/41).

## Rationale for changes ##

ULFM2 provides an alternate ULFM implementation for failed images support.

## Additional info and certifications ##

This pull request (PR) is a:

- [ ] Bug fix
- [X] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
