### PR TITLE
Fix compiler min ver check

### DIFF
--- a/prerequisites/install-functions/find_or_install.sh
+++ b/prerequisites/install-functions/find_or_install.sh
@@ -173,12 +173,12 @@ find_or_install()
 
         else
 
-          export minimum_acceptable_version=$(./build.sh -V gcc)
-          info "$this_script: Checking whether $executable in PATH wraps gfortran version >= $minimum_acceptable_version... "
+          export minimum_version=$(./build.sh -V gcc)
+          info "$this_script: Checking whether $executable in PATH wraps gfortran version >= $minimum_version... "
           $executable acceptable_compiler.f90 -o acceptable_compiler || true;
           $executable print_true.f90 -o print_true || true;
           if [[ -f ./acceptable_compiler && -f ./print_true ]]; then
-            acceptable=$(./acceptable_compiler $minimum_acceptable_version)
+            acceptable=$(./acceptable_compiler $minimum_version)
             is_true=$(./print_true)
             rm acceptable_compiler print_true
           else
@@ -279,8 +279,8 @@ find_or_install()
       $executable -o print_true print_true.f90 || true;
       if [[ -f ./acceptable_compiler && -f ./print_true ]]; then
         is_true=$(./print_true)
-        info "Executing './acceptable_compiler $minimum_acceptable_version'"
-        acceptable=$(./acceptable_compiler $minimum_acceptable_version)
+        info "Executing './acceptable_compiler $minimum_version'"
+        acceptable=$(./acceptable_compiler $minimum_version)
         rm acceptable_compiler print_true
       else
         acceptable=false

--- a/prerequisites/install-functions/find_or_install.sh
+++ b/prerequisites/install-functions/find_or_install.sh
@@ -173,12 +173,12 @@ find_or_install()
 
         else
 
-          export minimum_version=$(./build.sh -V gcc)
-          info "$this_script: Checking whether $executable in PATH wraps gfortran version >= $minimum_version... "
+          export minimum_compiler_version=$(./build.sh -V gcc)
+          info "$this_script: Checking whether $executable in PATH wraps gfortran version >= $minimum_compiler_version... "
           $executable acceptable_compiler.f90 -o acceptable_compiler || true;
           $executable print_true.f90 -o print_true || true;
           if [[ -f ./acceptable_compiler && -f ./print_true ]]; then
-            acceptable=$(./acceptable_compiler $minimum_version)
+            acceptable=$(./acceptable_compiler $minimum_compiler_version)
             is_true=$(./print_true)
             rm acceptable_compiler print_true
           else


### PR DESCRIPTION
## Summary of changes ##

Replaced erroneous variable name in `prerequisites/install-functions/find_or_install.sh`.

## Rationale for changes ##

In several places, an older name was being used for the bash variable `minimum_version`, resulting in an attempt to evaluate an unset variable.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code