### PR TITLE
Installer updates

### DIFF
--- a/prerequisites/build-functions/build_and_install.sh
+++ b/prerequisites/build-functions/build_and_install.sh
@@ -37,9 +37,13 @@ build_and_install()
       export cmake_binary_installer="${download_path}/cmake-${version_to_build}-Linux-x86_64.sh"
       ${SUDO:-} mkdir -p "$install_path"
       chmod u+x "${cmake_binary_installer}"
+      if [[ ! -z "${SUDO:-}" ]]; then
+        info "You do not have write permissions to the installation path ${install_path}"
+        info "If you have administrative privileges, enter your password to install ${package_to_build}"
+      fi
       info "Installing Cmake with the following command: "
-      info "\"${cmake_binary_installer}\" --prefix=\"$install_path\" --exclude-subdir"
-      "${cmake_binary_installer}" --prefix="$install_path" --exclude-subdir
+      info "${SUDO:-} \"${cmake_binary_installer}\" --prefix=\"$install_path\" --exclude-subdir"
+      ${SUDO:-} "${cmake_binary_installer}" --prefix="$install_path" --exclude-subdir
 
     else # build from source
 

--- a/prerequisites/build-functions/set_or_print_default_version.sh
+++ b/prerequisites/build-functions/set_or_print_default_version.sh
@@ -27,7 +27,7 @@ set_or_print_default_version()
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_version=(
     "cmake:3.10.0"
-    "gcc:8.2.0"
+    "gcc:8.3.0"
     "mpich:3.2"
     "wget:1.16.3"
     "flex:2.6.0"


### PR DESCRIPTION
<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

* Bump default/minimum GCC version to 8.3.0
* Facilitate `install.sh -p cmake -i <cmake-install-path>` with a cmake installation path that requires `sudo` privileges.

## Rationale for changes ##

* GCC 8.3.0 was released 22 February 2019
* When  we switched to binary installations of `cmake` on Linux, we forgot to all for installation paths that require `sudo`.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [X] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code