### PR TITLE
Use PIC for (default) static lib

### DIFF
--- a/prerequisites/install-functions/report_results.sh
+++ b/prerequisites/install-functions/report_results.sh
@@ -69,10 +69,10 @@ report_results()
     if [[ -d "${compiler_install_root%/}/lib" || -d "${compiler_install_root%/}/lib64" ]]; then
       echo "# Prepend the compiler library paths to the ${LD_LIB_P_VAR} environment variable:" | tee -a setup.sh setup.csh
       compiler_lib_paths="${compiler_install_root%/}/lib64/:${compiler_install_root%/}/lib"
-      echo "if [[ -z \"\${!LD_LIB_P_VAR}\" ]]; then                                       " >> setup.sh
+      echo "if [[ -z \"\${!${LD_LIB_P_VAR}}\" ]]; then                                    " >> setup.sh
       echo "  export ${LD_LIB_P_VAR}=\"${compiler_lib_paths%/}\"                          " >> setup.sh
       echo "else                                                                          " >> setup.sh
-      echo "  export ${LD_LIB_P_VAR}=\"${compiler_lib_paths%/}:\${!LD_LIB_P_VAR}\"        " >> setup.sh
+      echo "  export ${LD_LIB_P_VAR}=\"${compiler_lib_paths%/}:\${!${LD_LIB_P_VAR}}\"     " >> setup.sh
       echo "fi                                                                            " >> setup.sh
       echo "setenv LD_LIBRARY_PATH \"${compiler_lib_paths%/}:\${LD_LIBRARY_PATH}\"        " >> setup.csh
     fi

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -39,6 +39,9 @@ target_link_libraries(caf_mpi_static
   PUBLIC ${MPI_C_LINK_FLAGS}
   PUBLIC ${MPI_C_LIBRARIES}
   PRIVATE opencoarrays_mod)
+set_target_properties(caf_mpi_static
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE)
 target_include_directories(caf_mpi
   PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_INCLUDE_PATH}>)
 target_include_directories(caf_mpi_static


### PR DESCRIPTION
 `caf` wrapper script defaults to static linkage against libcaf_mpi.a but if you're
 building a shared lib with the `caf` script this fails because objects in `libcaf_mpi.a`
 are not compiled with `-fPIC`. So creating shared libs fails.

 The wrapper script should probably default to building and linking against the shared lib

<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
| ![Issue Stats][PR response img]   | ![Codecov branch][coverage] |

## Summary of changes ##

Always compile position independent code so that the caf wrapper script can build shared libs. Probably, the better solution is to link against the shared lib by default.

## Rationale for changes ##

Allow `caf` to compile JSON-Fortran

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
