### PR TITLE
Gfortran non determinism repeat

### DIFF
--- a/prerequisites/install-functions/report_results.sh
+++ b/prerequisites/install-functions/report_results.sh
@@ -60,7 +60,7 @@ report_results()
       echo "else                                                                          " >> setup.sh
       echo "  export PATH=\"${compiler_install_root%/}/bin:\${PATH}\"                     " >> setup.sh
       echo "fi                                                                            " >> setup.sh
-      echo "set path (\"${compiler_install_root%/}\"/bin \$path)                          " >> setup.csh
+      echo "set path = (\"${compiler_install_root%/}\"/bin \$path)                        " >> setup.csh
     fi
     LD_LIB_P_VAR=LD_LIBRARY_PATH
     if [[ "${OSTYPE:-}" =~ [Dd]arwin ]]; then

--- a/src/extensions/opencoarrays.F90
+++ b/src/extensions/opencoarrays.F90
@@ -581,13 +581,15 @@ contains
     character(kind=1,len=*), intent(out), optional :: errmsg
     ! Local variables and constants:
     integer(c_int), allocatable :: a_cast_to_integer_array(:)
+    character(len=len(a)) :: dummy
 
     ! Convert "a" to an integer(c_int) array where each 32-bit integer element holds four 1-byte characters
     a_cast_to_integer_array = transfer(a,[0_c_int])
     ! Broadcast the integer(c_int) array
     call co_broadcast_c_int(a_cast_to_integer_array,source_image, stat, errmsg)
     ! Recover the characters from the broadcasted integer(c_int) array
-    a = transfer(a_cast_to_integer_array,repeat(' ',len(a)))
+    dummy = ' '
+    a = transfer(a_cast_to_integer_array,dummy)
 
   end subroutine
 


### PR DESCRIPTION
<!-- Please fill out the pull request template included below, failure -->
<!-- to do so may result in immediate closure of your pull request. -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[PR response img]: https://img.shields.io/issuestats/p/github/sourceryinstitute/OpenCoarrays.svg?style=flat-square
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  Avg response time                |  coverage on master         |
|:---------------------------------:|:---------------------------:|
|    | ![Codecov branch][coverage] |

## Summary of changes ##

~~Repeat is VERY broken in GFortran 8.3~~; work around using it.

Also, it produces object files with error messages embedded in them with links to the source directory even when compiling with `-fno-working-directory`.

Added missing `=` in csh environment setup

## Rationale for changes ##

Work around bug for enabling reproducible builds.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I reviewed and followed the [contributing guidelines], including
      - Increasing test coverage for all feature-addition PRs
      - Increasing test coverage for all bug-fix PRs for which there
        does not already exist a related test that failed before the PR
      - At least maintaining test coverage for all other PRs
      - Ensuring that all tests pass when run locally 
      - Naming PR  to indicate work in progress (WIP) and to attach the PR
        to the appropriate bug report or feature request [issue]
      - White space (no trailing white space or white space errors may
        be introduced)
      - Commenting code where it is non-obvious and non-trivial
      - Logically atomic, self consistent and coherent commits
      - Commit message content
      - Waiting 24 hours before self-approving the PR to give another
        OpenCoarrays developer a chance to review my proposed code
