### PR TITLE
Fix dockerhub build hook

### DIFF
--- a/.Dockerfiles/master-jupyter-inherit/hooks/build
+++ b/.Dockerfiles/master-jupyter-inherit/hooks/build
@@ -58,5 +58,5 @@ docker build --build-arg OPENCOARRAYS_VERSION="${opencoarrays_version}" \
 	     --build-arg VCS_VERSION="${d_vcs_describe:-${d_tag}}" \
 	     --rm \
 	     --pull \
-             -t "${IMAGE_NAME:-$(tr '[:upper:]' '[:lower:]' <<< "${d_repo}_jupyter")}:latest" .
-docker tag "${IMAGE_NAME:-$(tr '[:upper:]' '[:lower:]' <<< "${d_repo}_jupyter")}:latest" "${IMAGE_NAME:-$(tr '[:upper:]' '[:lower:]' <<< "${d_repo}_jupyter")}:${d_vcs_tag}"
+             -t "${IMAGE_NAME:-$(tr '[:upper:]' '[:lower:]' <<< "${d_repo}_jupyter"):latest}" .
+docker tag "${IMAGE_NAME:-$(tr '[:upper:]' '[:lower:]' <<< "${d_repo}_jupyter"):latest}" "${IMAGE_NAME:-$(tr '[:upper:]' '[:lower:]' <<< "${d_repo}_jupyter"):${d_vcs_tag}}"


### PR DESCRIPTION
 - Extra/erroneous tags were being inserted when run on dockerhub infra

<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Dockerhub build hook (script)

## Rationale for changes ##

So that pushes to master will build the docker image and that can be used to launch a jupyter-CAF-kernel binder notebook based on the master branch.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
