### PR TITLE
Implement RFE #630

### DIFF
--- a/src/mpi/mpi_caf.c
+++ b/src/mpi/mpi_caf.c
@@ -8213,7 +8213,6 @@ void PREFIX(form_team) (int team_id, caf_team_t *team,
   MPI_Comm *current_comm = &CAF_COMM_WORLD;
   int ierr;
 
-  ierr = MPI_Barrier(CAF_COMM_WORLD); chk_err(ierr);
   newcomm = (MPI_Comm *)calloc(1,sizeof(MPI_Comm));
   ierr = MPI_Comm_split(*current_comm, team_id, caf_this_image, newcomm);
   chk_err(ierr);


### PR DESCRIPTION
Since #630 is about to be closed due to staleness, I went ahead and implemented the minor change suggested in the RFE.

## Summary of changes ##

Remove the superfluous MPI_Barrier() that is called during the execution of a FORM TEAM statement.

## Rationale for changes ##

MPI_Comm_split() alone is sufficient to provide image ordering semantics required by an image control statement like FORM TEAM.

This pull request (PR) is a:

- [ ] Bug fix
- [ ] Feature addition
- [X] Other, Please describe: optimization

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged
