### PR TITLE
fix for issue #672: Defect: caf script fails to fall back to dynamic …

### DIFF
--- a/src/extensions/caf.in
+++ b/src/extensions/caf.in
@@ -180,8 +180,8 @@ substitute_lib () {
       case "${1##*.}" in
           a|lib)
               for suff in so dylib dll ; do
-                  if [[ -f "${1%%.*}.${suff}" ]] ; then
-                      echo "${1%%.*}.${suff}"
+                  if [[ -f "${1%.*}.${suff}" ]] ; then
+                      echo "${1%.*}.${suff}"
                       return
                   fi
               done
@@ -191,8 +191,8 @@ substitute_lib () {
           ;;
           so|dylib|dll)
               for suff in a lib ; do
-                  if [[ -f "${1%%.*}.${suff}" ]] ; then
-                      echo "${1%%.*}.${suff}"
+                  if [[ -f "${1%.*}.${suff}" ]] ; then
+                      echo "${1%.*}.${suff}"
                       return
                   fi
               done


### PR DESCRIPTION
…libcaf if the static lib is missing

This fixes the substring removal pattern, we want the sortest matching
    suffix to make sure only the file suffix is replaced,
    e.g. libcaf_mpi.a by libcaf_mpi.so. This failed in paths containing
    more than one '.'

<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##
Only the caf wrapper script was changed, the function to find substitute libraries.

## Rationale for changes ##
The function didn't work, see issue #672 
## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
