### PR TITLE
fix #679: set FFLAGS for mpich configure with GCC >= 10

### DIFF
--- a/prerequisites/build-functions/build_and_install.sh
+++ b/prerequisites/build-functions/build_and_install.sh
@@ -25,11 +25,20 @@ build_and_install()
 
   if [[ "${package_to_build}" != "gcc" ]]; then
 
-    if [[ "${package_to_build}" == "mpich" && "${version_to_build}" == "3.2" ]]; then
-      info "Patching MPICH 3.2 on Mac OS due to segfault bug (see http://lists.mpich.org/pipermail/discuss/2016-May/004764.html)."
-      sed 's/} MPID_Request ATTRIBUTE((__aligned__(32)));/} ATTRIBUTE((__aligned__(32))) MPID_Request;/g' \
-        "${download_path}/${package_source_directory}/src/include/mpiimpl.h" > "${download_path}/${package_source_directory}/src/include/mpiimpl.h.patched"
-      cp "${download_path}/${package_source_directory}/src/include/mpiimpl.h.patched" "${download_path}/${package_source_directory}/src/include/mpiimpl.h"
+    if [[ "${package_to_build}" == "mpich" ]]; then
+      if [[ "${version_to_build}" == "3.2" ]]; then
+        info "Patching MPICH 3.2 on Mac OS due to segfault bug (see http://lists.mpich.org/pipermail/discuss/2016-May/004764.html)."
+        sed 's/} MPID_Request ATTRIBUTE((__aligned__(32)));/} ATTRIBUTE((__aligned__(32))) MPID_Request;/g' \
+          "${download_path}/${package_source_directory}/src/include/mpiimpl.h" > "${download_path}/${package_source_directory}/src/include/mpiimpl.h.patched"
+        cp "${download_path}/${package_source_directory}/src/include/mpiimpl.h.patched" "${download_path}/${package_source_directory}/src/include/mpiimpl.h"
+      fi
+
+      FC_version=$($FC --version)
+      text_before_dot="${FC_version%%.*}" # grab text before first dot
+      major_version="${text_before_dot##* }" # grab text after final space
+      if (( ${major_version} >= 10 )); then
+       export FFLAGS="-w -fallow-argument-mismatch"
+      fi
     fi
 
     if [[ "${package_to_build}" == "cmake"  && $(uname) == "Linux" ]]; then
@@ -48,8 +57,8 @@ build_and_install()
     else # build from source
 
       info "Configuring ${package_to_build} ${version_to_build} with the following command:"
-      info "FC=\"${FC:-'gfortran'}\" CC=\"${CC:-'gcc'}\" CXX=\"${CXX:-'g++'}\" \"${download_path}/${package_source_directory}\"/configure --prefix=\"${install_path}\""
-      FC="${FC:-'gfortran'}" CC="${CC:-'gcc'}" CXX="${CXX:-'g++'}" "${download_path}/${package_source_directory}"/configure --prefix="${install_path}"
+      info "FFLAGS=${FFLAGS:-} FC=\"${FC:-'gfortran'}\" CC=\"${CC:-'gcc'}\" CXX=\"${CXX:-'g++'}\" \"${download_path}/${package_source_directory}\"/configure --prefix=\"${install_path}\""
+      FFLAGS=${FFLAGS:-} FC="${FC:-'gfortran'}" CC="${CC:-'gcc'}" CXX="${CXX:-'g++'}" "${download_path}/${package_source_directory}"/configure --prefix="${install_path}"
       info "Building with the following command:"
       info "FC=\"${FC:-'gfortran'}\" CC=\"${CC:-'gcc'}\" CXX=\"${CXX:-'g++'}\" make -j\"${num_threads}\""
       FC="${FC:-'gfortran'}" CC="${CC:-'gcc'}" CXX="${CXX:-'g++'}" make "-j${num_threads}"

--- a/prerequisites/build-functions/build_and_install.sh
+++ b/prerequisites/build-functions/build_and_install.sh
@@ -100,8 +100,8 @@ build_and_install()
     info "Configuring gcc/g++/gfortran builds with the following command:"
     info "${download_path}/${package_source_directory}/configure --prefix=${install_path} --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror ${bootstrap_configure}"
     "${download_path}/${package_source_directory}/configure" --prefix="${install_path}" --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror "${bootstrap_configure}"
-    info "Building with the following command: 'make -j${num_threads} ${bootstrap_build}'"
-    make "-j${num_threads}" "${bootstrap_build}"
+    info "Building with the following command: make -j ${num_threads} ${bootstrap_build}"
+    make -j ${num_threads} ${bootstrap_build:-}
     if [[ -n "${SUDO:-}" ]]; then
       info "You do not have write permissions to the installation path ${install_path}"
       info "If you have administrative privileges, enter your password to install ${package_to_build}"

--- a/prerequisites/build-functions/build_and_install.sh
+++ b/prerequisites/build-functions/build_and_install.sh
@@ -21,7 +21,7 @@ build_and_install()
   fi
   mkdir -p "${build_path}"
   info "pushd ${build_path}"
-  pushd "${build_path}"
+  pushd "${build_path}" || emergency "build_and_install.sh: pushd failed"
 
   if [[ "${package_to_build}" != "gcc" ]]; then
 
@@ -46,7 +46,7 @@ build_and_install()
       export cmake_binary_installer="${download_path}/cmake-${version_to_build}-Linux-x86_64.sh"
       ${SUDO:-} mkdir -p "$install_path"
       chmod u+x "${cmake_binary_installer}"
-      if [[ ! -z "${SUDO:-}" ]]; then
+      if [[ -n "${SUDO:-}" ]]; then
         info "You do not have write permissions to the installation path ${install_path}"
         info "If you have administrative privileges, enter your password to install ${package_to_build}"
       fi
@@ -63,7 +63,7 @@ build_and_install()
       info "FC=\"${FC:-'gfortran'}\" CC=\"${CC:-'gcc'}\" CXX=\"${CXX:-'g++'}\" make -j\"${num_threads}\""
       FC="${FC:-'gfortran'}" CC="${CC:-'gcc'}" CXX="${CXX:-'g++'}" make "-j${num_threads}"
       info "Installing ${package_to_build} in ${install_path}"
-      if [[ ! -z "${SUDO:-}" ]]; then
+      if [[ -n "${SUDO:-}" ]]; then
         info "You do not have write permissions to the installation path ${install_path}"
         info "If you have administrative privileges, enter your password to install ${package_to_build}"
       fi
@@ -75,7 +75,7 @@ build_and_install()
   elif [[ ${package_to_build} == "gcc" ]]; then
 
     info "pushd ${download_path}/${package_source_directory} "
-    pushd "${download_path}/${package_source_directory}"
+    pushd "${download_path}/${package_source_directory}" || emergency "build_and_install.sh: pushd failed"
 
     # Patch gfortran if necessary
     export patches_dir="${OPENCOARRAYS_SRC_DIR}/prerequisites/build-functions/patches/${package_to_build}/${version_to_build}"
@@ -96,13 +96,13 @@ build_and_install()
     "${PWD}"/contrib/download_prerequisites
 
     info "popd"
-    popd
+    popd || emergency "build_and_install.sh: popd failed"
     info "Configuring gcc/g++/gfortran builds with the following command:"
     info "${download_path}/${package_source_directory}/configure --prefix=${install_path} --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror ${bootstrap_configure}"
-    "${download_path}/${package_source_directory}/configure" --prefix="${install_path}" --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror ${bootstrap_configure}
+    "${download_path}/${package_source_directory}/configure" --prefix="${install_path}" --enable-languages=c,c++,fortran,lto --disable-multilib --disable-werror "${bootstrap_configure}"
     info "Building with the following command: 'make -j${num_threads} ${bootstrap_build}'"
-    make "-j${num_threads}" ${bootstrap_build}
-    if [[ ! -z "${SUDO:-}" ]]; then
+    make "-j${num_threads}" "${bootstrap_build}"
+    if [[ -n "${SUDO:-}" ]]; then
       info "You do not have write permissions to the installation path ${install_path}"
       info "If you have administrative privileges, enter your password to install ${package_to_build}"
     fi
@@ -115,5 +115,5 @@ build_and_install()
 
 
   info "popd"
-  popd
+  popd || emergency "build_and_install.sh: popd failed"
 }


### PR DESCRIPTION
<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

With this PR, `install.sh` will set `FFLAGS="-w -fallow-argument-mismatch"` when building MPICH with GCC versions >= 10. 

## Rationale for changes ##

GCC 10 reports an error when procedure arguments mismatch even in Fortran 77 procedures with implicit interfaces.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged

## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
