### PR TITLE
Fix #683 check compiler version

### DIFF
--- a/prerequisites/acceptable_compiler.f90
+++ b/prerequisites/acceptable_compiler.f90
@@ -103,7 +103,7 @@ contains
 
   end function
 
- pure function minor(version_string) result(minor_value)
+  pure function minor(version_string) result(minor_value)
     character(len=*), intent(in) :: version_string
     integer minor_value
     character(len=:), allocatable :: middle_digits
@@ -117,20 +117,30 @@ contains
 
   end function
 
- pure function patch(version_string) result(patch_value)
+  pure function patch(version_string) result(patch_value)
     character(len=*), intent(in) :: version_string
     integer patch_value
     character(len=:), allocatable :: trailing_digits
 
     associate( first_dot => scan(version_string, '.') )
       associate( second_dot => first_dot + scan(version_string(first_dot+1:), '.') )
-        associate( first_non_digit=> second_dot + scan(version_string(second_dot+1:), ' ') )
+        associate( first_non_digit=> second_dot + first_printable_non_digit(version_string(second_dot+1:)) )
           trailing_digits = version_string( second_dot+1 : first_non_digit-1 )
           read(trailing_digits,*) patch_value
         end associate
       end associate
     end associate
 
+  end function
+
+  pure function first_printable_non_digit( string ) result(location)
+    character(len=*), intent(in) :: string
+    integer i, location
+    integer, parameter :: ASCII_non_digit(*)=[(i,i=32,47),(i,i=58,126)]
+    character(len=1), parameter :: non_digit(*)=[( char(ASCII_non_digit(i)) , i=1, size(ASCII_non_digit) )]
+    character(len=size(non_digit)) non_digit_string
+    write(non_digit_string,'(85a)') non_digit
+    location = scan(string,non_digit_string)
   end function
 
 end program

--- a/prerequisites/acceptable_compiler.f90
+++ b/prerequisites/acceptable_compiler.f90
@@ -33,21 +33,104 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 
 program main
+  !! input: acceptable compiler version the form major.minor.patch
+  !! output:
+  !!   .true. if compiler version >= acceptable version
+  !!   .false. otherwise
   use iso_fortran_env, only : compiler_version
   implicit none
-  integer, parameter :: first_argument=1
+
+  integer, parameter :: first_argument=1, max_version_length=len('999.999.999')
   integer stat
-  character(len=9) version_number
-  call get_command_argument(first_argument,version_number,status=stat)
-  select case(stat)
-    case(-1)
-       error stop "acceptable_compiler.f90: insufficient string length in attempt to read command argument"
-    case(0)
-      ! successful command argument read
-    case(1:)
-       error stop "acceptable_compiler.f90: no version-number supplied"
-    case default
-       error stop "invalid status"
-  end select
-  print *,(compiler_version() >= "GCC version "//adjustl(trim(version_number))//" ")
+  character(len=max_version_length) acceptable_version
+
+  call get_command_argument(first_argument,acceptable_version,status=stat)
+  call validate_command_line( stat )
+
+  associate( compiler_version=> compiler_version() )
+    associate(major_version=>major(compiler_version), acceptable_major=>major(acceptable_version))
+      if ( major_version > acceptable_major ) then
+        print *,.true.
+      else if ( major_version == acceptable_major ) then
+        associate(minor_version=>minor(compiler_version), acceptable_minor=>minor(acceptable_version))
+          if ( minor_version > acceptable_minor ) then
+            print *,.true.
+          else if ( minor_version == acceptable_minor ) then
+            associate(patch_version=>patch(compiler_version), acceptable_patch=>patch(acceptable_version))
+              if ( patch_version >= acceptable_patch ) then
+                print *,.true.
+              else
+                print *,.false.
+              end if
+            end associate
+          else
+            print *,.false.
+          end if
+        end associate
+      else
+        print *,.false.
+      end if
+    end associate
+  end associate
+
+contains
+
+  subroutine validate_command_line( command_line_status )
+    integer, intent(in) :: command_line_status
+    select case(command_line_status)
+      case(-1)
+         error stop "acceptable_compiler.f90: insufficient string length in attempt to read command argument"
+      case(0)
+        ! successful command argument read
+      case(1:)
+         error stop "acceptable_compiler.f90: no version-number supplied"
+      case default
+         error stop "invalid status"
+    end select
+   end subroutine
+
+  pure function major(version_string) result(major_value)
+    character(len=*), intent(in) :: version_string
+    integer major_value
+    character(len=:), allocatable :: leading_digits
+
+    associate( first_dot => scan(version_string, '.') )
+      associate( first_digit => scan( version_string(1:first_dot-1), '0123456789' ) )
+        leading_digits = version_string( first_digit : first_dot-1  )
+        read(leading_digits,*) major_value
+      end associate
+    end associate
+
+  end function
+
+ pure function minor(version_string) result(minor_value)
+    character(len=*), intent(in) :: version_string
+    integer minor_value
+    character(len=:), allocatable :: middle_digits
+
+    associate( first_dot => scan(version_string, '.') )
+      associate( second_dot => first_dot + scan(version_string(first_dot+1:), '.') )
+        middle_digits = version_string( first_dot+1 : second_dot-1 )
+        read(middle_digits,*) minor_value
+      end associate
+    end associate
+
+  end function
+
+ pure function patch(version_string) result(patch_value)
+    character(len=*), intent(in) :: version_string
+    integer patch_value
+    character(len=:), allocatable :: trailing_digits
+
+    associate( first_dot => scan(version_string, '.') )
+      associate( second_dot => first_dot + scan(version_string(first_dot+1:), '.') )
+        associate( first_non_digit=> second_dot + scan(version_string(second_dot+1:), ' ') )
+          trailing_digits = version_string( second_dot+1 : first_non_digit-1 )
+          read(trailing_digits,*) patch_value
+        end associate
+      end associate
+    end associate
+
+  end function
+
 end program


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Improved `acceptable_compiler.f90`.

## Rationale for changes ##

Previous version failed for double-digit major version numbers.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
