### PR TITLE
Update GCC default-minimum version to 10.1.0 & fix compiler version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,17 +543,17 @@ function(caf_compile_executable target main_depend)
   foreach(d ${DirDefs})
     list(APPEND localDefs "-D${d}")
   endforeach()
-    add_custom_command(OUTPUT "${target}"
-      COMMAND "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/caf"
-                 ${includes} ${localDefs} ${config_Fortran_flags}
-                 -o "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${target}"
-                 "${CMAKE_CURRENT_SOURCE_DIR}/${main_depend}"
-		 "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopencoarrays_test_utilities.a"
-		 "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopencoarrays_mod.a"
-		 ${ARGN}
-      DEPENDS "${main_depend}" ${ARGN} caf_mpi_static opencoarrays_test_utilities opencoarrays_mod
-      VERBATIM
-      )
+  add_custom_command(OUTPUT "${target}"
+    COMMAND "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/caf"
+            ${includes} ${localDefs} ${config_Fortran_flags}
+            -o "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${target}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/${main_depend}"
+            $<TARGET_FILE:opencoarrays_test_utilities>
+            $<TARGET_FILE:opencoarrays_mod>
+            ${ARGN}
+    DEPENDS "${main_depend}" ${ARGN} caf_mpi_static opencoarrays_test_utilities opencoarrays_mod
+    VERBATIM
+    )
   add_custom_target("build_${target}" ALL
     DEPENDS "${target}")
 endfunction(caf_compile_executable)

--- a/INSTALL
+++ b/INSTALL
@@ -11,16 +11,14 @@ Developer/quickstart installation guide
 How to build OpenCoarrays for the very impatient
 ------------------------------------------------
 
-    mkdir opencoarrays-build
-    cd opencoarrays-build
-    export FC=/path/to/gfortran
-    export CC=/path/to/gcc
-    cmake /path/to/OpenCoarrays/source \
-      -DCMAKE_INSTALL_PREFIX=/path/to/desired/installation/location
+    git clone https://github.com/sourceryinstitute/OpenCoarrays
+    cd OpenCoarrays
+    mkdir build
+    cd build
+    cmake ..
     make
     make test # optional; verify build works
-    make install
-
+    sudo make install
 
 Intended audience
 -----------------

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2016, Sourcery Institute
+Copyright (c) 2016-2020, Sourcery Institute
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/install.sh-usage
+++ b/install.sh-usage
@@ -1,4 +1,4 @@
-  -b --install-branch [arg]   Install the specified repository development branch (Examples: -b trunk or -b gcc-7-branch).
+  -b --install-branch [arg]   Install the specified repository development branch (Examples: -b master).
   -c --with-c [arg]           Use specified C compiler (Example: -c /usr/local/bin/gcc).
   -C --with-cxx [arg]         Use specified C++ compiler (Example: -C /usr/local/bin/g++).
   -d --debug                  Enable debug mode.

--- a/prerequisites/acceptable_compiler.f90
+++ b/prerequisites/acceptable_compiler.f90
@@ -33,7 +33,7 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 
 program main
-  !! input: acceptable compiler version the form major.minor.patch
+  !! input: acceptable compiler version in the form major.minor.patch
   !! output:
   !!   .true. if compiler version >= acceptable version
   !!   .false. otherwise
@@ -47,41 +47,40 @@ program main
   call get_command_argument(first_argument,acceptable_version,status=stat)
   call validate_command_line( stat )
 
-  print *, patch_meets_minimum( acceptable_version )
+  print *, meets_minimum( acceptable_version )
 
 contains
 
-  pure function patch_meets_minimum( required_version ) result( is_acceptable)
+  pure function meets_minimum( required_version ) result( acceptable)
     character(len=*), intent(in) :: required_version
-    logical is_acceptable
+    logical acceptable
 
-    is_acceptable = .false. ! default result
+    acceptable = .false. ! default result
 
     associate( actual_version => compiler_version() )
       associate(major_version=>major(actual_version), acceptable_major=>major(required_version))
         if (major_version < acceptable_major) return
         if (major_version > acceptable_major) then
-          is_acceptable = .true.
+          acceptable = .true.
           return
         end if
         associate(minor_version=>minor(actual_version), acceptable_minor=>minor(required_version))
           if (minor_version < acceptable_minor) return
           if (minor_version > acceptable_minor) then
-            is_acceptable = .true.
+            acceptable = .true.
             return
           end if
           associate(patch_version=>patch(actual_version), acceptable_patch=>patch(required_version))
             if (patch_version < acceptable_patch) return
-            is_acceptable = .true.
+            acceptable = .true.
           end associate
         end associate
       end associate
     end associate
 
-
   end function
 
-  subroutine validate_command_line( command_line_status )
+  pure subroutine validate_command_line( command_line_status )
     integer, intent(in) :: command_line_status
     select case(command_line_status)
       case(-1)

--- a/prerequisites/build-functions/download_if_necessary.sh
+++ b/prerequisites/build-functions/download_if_necessary.sh
@@ -58,7 +58,7 @@ download_if_necessary()
       ;;
    esac
 
-  if  [[ -f "${download_path}/${url_tail}" || -d "${download_path}/${url_tail##*branches/}" && ! -z ${url_tail##*branches/} ]]; then
+  if  [[ -f "${download_path}/${url_tail}" || -d "${download_path}/${url_tail}" ]]; then
     info "Found '${url_tail##*branches/}' in ${download_path}."
     info "If it resulted from an incomplete download, building ${package_name} could fail."
     if [[ "${arg_y}" == "${__flag_present}" ]]; then

--- a/prerequisites/build-functions/set_or_print_default_version.sh
+++ b/prerequisites/build-functions/set_or_print_default_version.sh
@@ -27,7 +27,7 @@ set_or_print_default_version()
   # See http://stackoverflow.com/questions/1494178/how-to-define-hash-tables-in-bash
   package_version=(
     "cmake:3.10.0"
-    "gcc:8.3.0"
+    "gcc:10.1.0"
     "mpich:3.2"
     "wget:1.16.3"
     "flex:2.6.0"

--- a/prerequisites/build-functions/set_or_print_default_version.sh
+++ b/prerequisites/build-functions/set_or_print_default_version.sh
@@ -20,6 +20,10 @@ set_or_print_default_version()
     exit 0
   fi
 
+  if [[ $(uname) == "Darwin" ]]; then
+    apple_flex_version="2.5.35"
+  fi
+
   [ "${package_name}" == "opencoarrays" ] &&
     emergency "Please use this script with a previously downloaded opencoarrays source archive. This script does not download opencoarrays "
   # This is a bash 3 hack standing in for a bash 4 hash (bash 3 is the lowest common
@@ -30,7 +34,7 @@ set_or_print_default_version()
     "gcc:10.1.0"
     "mpich:3.2"
     "wget:1.16.3"
-    "flex:2.6.0"
+    "flex:${apple_flex_version:-2.6.0}"
     "bison:3.0.4"
     "pkg-config:0.28"
     "make:4.1"

--- a/prerequisites/build-functions/set_or_print_downloader.sh
+++ b/prerequisites/build-functions/set_or_print_downloader.sh
@@ -7,17 +7,19 @@ set_or_print_downloader()
 {
   # Verify requirements
   [ ! -z "${arg_D}" ] && [ ! -z "${arg_p:-${arg_P:-${arg_U:-${arg_V}}}}" ] &&
-    emergency "Please pass only one of {-B, -D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
+    emergency "Please pass only one of {-D, -p, -P, -U, -V} or a longer equivalent (multiple detected)."
 
   package_name="${arg_p:-${arg_D:-${arg_P:-${arg_U:-${arg_V}}}}}"
 
-  if [[ "${package_name}" == "ofp" ]]; then
+  if [[ "${package_name}" == "gcc" ]]; then
+    arg_b=${arg_b:-releases/gcc-${version_to_build}}
+  elif [[ "${package_name}" == "ofp" ]]; then
     "${OPENCOARRAYS_SRC_DIR}/prerequisites/install-ofp.sh" "${@}"
     exit 0
   fi
 
   # Choose the first available download mechanism, prioritizing first any absolute requirement
-  # (git for gcc development branches) and second robustness:
+  # (git for gcc) and second robustness:
   info "Checking available download mechanisms: ftp, wget, and curl."
   info "\${package_name}=${package_name}  \${arg_b:-}=${arg_b:-}"
 
@@ -26,7 +28,7 @@ set_or_print_downloader()
   elif type wget &> /dev/null; then
     gcc_prereqs_fetch=wget
   elif type ftp &> /dev/null; then
-    if [[ "${package_name}" == "gcc"   || "${package_name}" == "wget" || "${package_name}" == "make" ||
+    if [[ "${package_name}" == "wget" || "${package_name}" == "make" ||
           "${package_name}" == "bison" || "${package_name}" == "m4"   ]]; then
       gcc_prereqs_fetch=ftp_url
     fi
@@ -34,7 +36,7 @@ set_or_print_downloader()
     tried="curl, wget, and ftp"
   fi
 
-  if [[ "${package_name}" == "gcc" && ! -z "${arg_b}" ]]; then
+  if [[ "${package_name}" == "gcc" ]]; then
     if type git &> /dev/null; then
       fetch=git
     else
@@ -45,7 +47,7 @@ set_or_print_downloader()
   fi
 
   if [[ -z "${fetch:-}" ]]; then
-    emergency "No available download mechanism. Option tried: ${tried}"
+    emergency "No available download mechanism. Option(s) tried: ${tried}"
   fi
 
   # If a printout of the download mechanism was requested, then print it and exit with normal status

--- a/prerequisites/build-functions/set_or_print_url.sh
+++ b/prerequisites/build-functions/set_or_print_url.sh
@@ -46,7 +46,7 @@ else
 
   # Set differing tails for GCC release downloads versus development branch checkouts
   package_url_tail=(
-    "gcc;gcc.git"
+    "gcc;gcc"
     "wget;wget-${version_to_build-}.tar.gz"
     "m4;m4-${version_to_build-}.tar.bz2"
     "pkg-config;pkg-config-${version_to_build-}.tar.gz"

--- a/prerequisites/build-functions/set_or_print_url.sh
+++ b/prerequisites/build-functions/set_or_print_url.sh
@@ -19,15 +19,9 @@ else
 
   if [[ "${package_to_build}" == 'cmake' ]]; then
     major_minor="${version_to_build%.*}"
-  elif [[ "${package_to_build}" == "gcc" ]]; then
-    if [[ -z "${arg_b}" ]]; then
-      gcc_url_head="https://ftpmirror.gnu.org/gcc/gcc-${version_to_build}/"
-    else
-      gcc_url_head="git://gcc.gnu.org/git/"
-    fi
   fi
   package_url_head=(
-    "gcc;${gcc_url_head-}"
+    "gcc;https://gcc.gnu.org/git/"
     "wget;https://ftpmirror.gnu.org/gnu/wget/"
     "m4;https://ftpmirror.gnu.org/gnu/m4/"
     "pkg-config;https://pkgconfig.freedesktop.org/releases/"
@@ -51,15 +45,8 @@ else
   done
 
   # Set differing tails for GCC release downloads versus development branch checkouts
-  if [[ "${package_to_build}" == 'gcc' ]]; then
-    if [[ "${fetch}" == 'git' ]]; then
-      gcc_tail="gcc"
-    else
-      gcc_tail="gcc-${version_to_build}.tar.gz"
-    fi
-  fi
   package_url_tail=(
-    "gcc;${gcc_tail-}"
+    "gcc;gcc.git"
     "wget;wget-${version_to_build-}.tar.gz"
     "m4;m4-${version_to_build-}.tar.bz2"
     "pkg-config;pkg-config-${version_to_build-}.tar.gz"

--- a/prerequisites/build.sh-usage
+++ b/prerequisites/build.sh-usage
@@ -1,5 +1,4 @@
-  -b --install-branch [arg]   Install the specified repository development branch.
-  -B --list-branches [arg]    List the available branches in the specified package's repository.
+  -b --install-branch [arg]   Install the specified repository development branch (Examples: -b master).
   -c --with-c [arg]           Use the specified C compiler. Default="gcc"
   -C --with-cxx [arg]         Use the specified C++ compiler. Default="g++"
   -d --debug                  Enable debug mode.

--- a/prerequisites/check_version.sh
+++ b/prerequisites/check_version.sh
@@ -5,8 +5,8 @@
 # -- Verify whether an OpenCoarrays prerequisite meets the required minimum version number.
 #
 # OpenCoarrays is distributed under the OSI-approved BSD 3-clause License:
-# Copyright (c) 2015-2016, Sourcery, Inc.
-# Copyright (c) 2015-2016, Sourcery Institute
+# Copyright (c) 2015-2020, Sourcery, Inc.
+# Copyright (c) 2015-2020, Sourcery Institute
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -44,7 +44,7 @@ this_script=$(basename "$0")
 usage()
 {
     echo ""
-    echo " $this_script - Bash script for verifyin minimum version numbers for OpenCoarrays prerequisites"
+    echo " $this_script - Bash script for verifying minimum version numbers for OpenCoarrays prerequisites"
     echo ""
     echo " Usage (optional arguments in square brackets): "
     echo "      $this_script [<option>]"
@@ -104,21 +104,28 @@ if [[ "$verbose" == "--verbose" ]]; then
   echo "$package_version_header"
 fi
 
-# Extract the text after the final space:
-version=${package_version_header##* }
-major=${version%%.*}
-minor_patch=${version#*.}
-minor=${minor_patch%%.*}
-patch=${version##*.}
-if [[ "$verbose" == "--verbose" ]]; then
-  echo "$version = $major . $minor . $patch"
+before_first_dot="${package_version_header%%.*}"
+major="${before_first_dot##* }" # grab text after final space in remaining string
+
+after_first_dot="${package_version_header#*.}"
+minor="${after_first_dot%%.*}"
+
+after_final_dot="${package_version_header##*.}" # grab text after final dot
+if [[ "$after_final_dot" == "$after_first_dot" ]]; then
+  patch=""
+else
+  patch="${after_final_dot%% *}"
 fi
 
-# Extract the text after the final space:
+if [[ "$verbose" == "--verbose" ]]; then
+  echo "$major . $minor . $patch"
+fi
+
 min_major=${minimum_version%%.*}
 min_minor_patch=${minimum_version#*.}
 min_minor=${min_minor_patch%%.*}
 min_patch=${minimum_version##*.}
+
 if [[ "$verbose" == "--verbose" ]]; then
   echo "$minimum_version = $min_major . $min_minor . $min_patch"
 fi

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -308,7 +308,7 @@ configure_file("${CMAKE_SOURCE_DIR}/src/extensions/caf.in" "${CMAKE_BINARY_DIR}/
   @ONLY)
 
 
-# List of carrun.in variables needing configuration:
+# List of cafrun.in variables needing configuration:
 #
 # @CAF_VERSION@ @MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ @MPIEXEC_PREFLAGS@ @MPIEXEC_POSTFLAGS@
 # @HAVE_FAILED_IMG@

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -22,7 +22,9 @@ set_target_properties(opencoarrays_mod
   Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${mod_dir_tail}"
   POSITION_INDEPENDENT_CODE TRUE)
 target_compile_options(opencoarrays_mod
-  PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${MPI_Fortran_COMPILE_FLAGS}>)
+  PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${MPI_Fortran_COMPILE_OPTIONS}>)
+target_compile_definitions(opencoarrays_mod
+  PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${MPI_Fortran_COMPILE_DEFINITIONS}>)
 target_link_libraries(opencoarrays_mod
   PUBLIC ${MPI_Fortran_LINK_FLAGS}
   PUBLIC ${MPI_Fortran_LIBRARIES})
@@ -53,9 +55,13 @@ target_include_directories(caf_mpi_static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_options(caf_mpi
-  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_FLAGS}>)
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_OPTIONS}>)
+target_compile_definitions(caf_mpi
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_DEFINITIONS}>)
 target_compile_options(caf_mpi_static
-  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_FLAGS}>)
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_OPTIONS}>)
+target_compile_definitions(caf_mpi_static
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_DEFINITIONS}>)
 
 set(CAF_SO_VERSION 0)
 if(gfortran_compiler)

--- a/src/tests/utilities/CMakeLists.txt
+++ b/src/tests/utilities/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library( oc_test_interfaces OBJECT
   opencoarrays_object_interface.f90
   oc_assertions_interface.F90
   )
-add_library( opencoarrays_test_utilities
+add_library( opencoarrays_test_utilities STATIC
   oc_assertions_implementation.F90
   $<TARGET_OBJECTS:oc_test_interfaces>
   )


### PR DESCRIPTION

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Set `install.sh` to default to building GCC 10.1.0 if an earlier version is detected and no other version is specified.  This can still be over-rided for users who want to build OpenCoarrays with an older version by passing the `-f`, `-c`, and `-C` arguments (or their longer equivalents).

## Rationale for changes ##

1. This ensures co_broadcast handles derived type arguments.
2. This also updates the gcc download to use `git` because GCC has moved from `svn` to `git` and 
 because many users cannot access the GCC `ftp` server for security reasons.
3. This merge also fixes problems with `prerequisites/acceptable_compiler.f90`, which failed when the acceptable compiler version matched the actual version.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix (replaces GCC download URL's that don't work for the latest releases)
- [X] Feature addition (provides derived-type `co_broadcast` by default)
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
