### PR TITLE
Fix MPI compile flags to not include quotation marks (issue-704)

### DIFF
--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -22,7 +22,9 @@ set_target_properties(opencoarrays_mod
   Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${mod_dir_tail}"
   POSITION_INDEPENDENT_CODE TRUE)
 target_compile_options(opencoarrays_mod
-  PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${MPI_Fortran_COMPILE_FLAGS}>)
+  PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${MPI_Fortran_COMPILE_OPTIONS}>)
+target_compile_definitions(opencoarrays_mod
+  PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${MPI_Fortran_COMPILE_DEFINITIONS}>)
 target_link_libraries(opencoarrays_mod
   PUBLIC ${MPI_Fortran_LINK_FLAGS}
   PUBLIC ${MPI_Fortran_LIBRARIES})
@@ -53,9 +55,13 @@ target_include_directories(caf_mpi_static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_options(caf_mpi
-  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_FLAGS}>)
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_OPTIONS}>)
+target_compile_definitions(caf_mpi
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_DEFINITIONS}>)
 target_compile_options(caf_mpi_static
-  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_FLAGS}>)
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_OPTIONS}>)
+target_compile_definitions(caf_mpi_static
+  PUBLIC $<$<COMPILE_LANGUAGE:C>:${MPI_C_COMPILE_DEFINITIONS}>)
 
 set(CAF_SO_VERSION 0)
 if(gfortran_compiler)


### PR DESCRIPTION
[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

- replaced string of space separated MPI compile flags in generator expression
  in cmake function `target_compile_options` by a list
- used function `target_compile_definitions` for the compile definitions instead of appending
  them to the compile options

## Rationale for changes ##

The function `target_compile_options` in combination with
generator expressions does not handle strings with space
separated compiler flags and instead interprets all flags as a single one,
thus adding quotes.

Also `MPI_<lang>_COMPILE_FLAGS` is [deprecated since cmake 3.10](https://cmake.org/cmake/help/v3.10/module/FindMPI.html?highlight=findmpi#backward-compatibility)
and should be replaced by `MPI_<lang>_COMPILE_OPTIONS` and
`MPI_<lang>_COMPILE_DEFINITIONS`.
Those variables are already lists of compiler flags and thus well
suited to solve the bug.

## Additional info and certifications ##

This fixes the build errors described in issue #704 and issue #676 (when building first for MPICH).

This fix was tested on Fedora 32 with the standard installations of gcc, cmake, mpich and openmpi:
  - gcc: 10.1.1 20200507
  - cmake: 3.17.2
  - mpich: 3.3.2
  - openmpi: 4.0.3

With MPICH all tests passed without error.
With OpenMPI the following tests failed (the same as on the master branch and already reported in issue #703):
  - 11 (async_comp_alloc_2)
  - 12 (comp_allocated_1)
  - 13 (comp_allocated_2)
  - 14 (alloc_comp_get_convert_nums)
  - 29 (alloc_comp_send_convert_nums)
  - 78 (issue-515-mimic-mpi-gatherv)

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - ~~I have you written new tests for these changes~~
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
