### PR TITLE
Fix static lib opencoarrays_test_utilities not found (issue  676)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,17 +543,17 @@ function(caf_compile_executable target main_depend)
   foreach(d ${DirDefs})
     list(APPEND localDefs "-D${d}")
   endforeach()
-    add_custom_command(OUTPUT "${target}"
-      COMMAND "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/caf"
-                 ${includes} ${localDefs} ${config_Fortran_flags}
-                 -o "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${target}"
-                 "${CMAKE_CURRENT_SOURCE_DIR}/${main_depend}"
-		 "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopencoarrays_test_utilities.a"
-		 "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopencoarrays_mod.a"
-		 ${ARGN}
-      DEPENDS "${main_depend}" ${ARGN} caf_mpi_static opencoarrays_test_utilities opencoarrays_mod
-      VERBATIM
-      )
+  add_custom_command(OUTPUT "${target}"
+    COMMAND "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/caf"
+            ${includes} ${localDefs} ${config_Fortran_flags}
+            -o "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${target}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/${main_depend}"
+            $<TARGET_FILE:opencoarrays_test_utilities>
+            $<TARGET_FILE:opencoarrays_mod>
+            ${ARGN}
+    DEPENDS "${main_depend}" ${ARGN} caf_mpi_static opencoarrays_test_utilities opencoarrays_mod
+    VERBATIM
+    )
   add_custom_target("build_${target}" ALL
     DEPENDS "${target}")
 endfunction(caf_compile_executable)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -308,7 +308,7 @@ configure_file("${CMAKE_SOURCE_DIR}/src/extensions/caf.in" "${CMAKE_BINARY_DIR}/
   @ONLY)
 
 
-# List of carrun.in variables needing configuration:
+# List of cafrun.in variables needing configuration:
 #
 # @CAF_VERSION@ @MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ @MPIEXEC_PREFLAGS@ @MPIEXEC_POSTFLAGS@
 # @HAVE_FAILED_IMG@

--- a/src/tests/utilities/CMakeLists.txt
+++ b/src/tests/utilities/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library( oc_test_interfaces OBJECT
   opencoarrays_object_interface.f90
   oc_assertions_interface.F90
   )
-add_library( opencoarrays_test_utilities
+add_library( opencoarrays_test_utilities STATIC
   oc_assertions_implementation.F90
   $<TARGET_OBJECTS:oc_test_interfaces>
   )


### PR DESCRIPTION
<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

  - mark target `opencoarrays_test_utilities` as static
  - use generator expression to link to a generated library instead of hard coding the path
  - fix typo

Summarize what you changed

## Rationale for changes ##

When building with `BUILD_SHARED_LIBS=ON` `opencoarrays_test_utilities` was
build as a shared library but in the function `caf_compile_executable`
it is hard coded as a static library. Thus leading to the build error described in issue #676.

## Additional info and certifications ##

The pre-push hook fails with 'WIP' found, when one tries to push a new branch not yet existent on the remote.

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
