### PR TITLE
Fix #717 cafrun usage message

### DIFF
--- a/.VERSION
+++ b/.VERSION
@@ -1,6 +1,6 @@
 $Format:%d%n%n$
 # Fall back version, probably last release:
-2.9.0
+2.9.1
 
 # OpenCoarrays version file. This project uses semantic
 # versioning. For details see http://semver.org

--- a/src/extensions/cafrun.in
+++ b/src/extensions/cafrun.in
@@ -155,6 +155,7 @@ usage() {
   echo "   --version, -v, -V        Report version and copyright information"
   echo "   --wraps, -w,             Report info about the wrapped MPI launcher"
   echo "   -np <N>,                 Number of images, N, to execute, N must be a positive integer"
+  echo "   -n <N>,                  Same as -np"
   echo "   --reenable-auto-cleanup  Turn off failed images support (if library support is present)"
   echo "                            This option re-enables MPI auto cleanup, which is disabled by"
   echo "                            by default if GFortran/OpenCoarrays/MPI all support failed"
@@ -168,6 +169,7 @@ usage() {
   echo ""
   echo " Example usage:"
   echo ""
+  echo "   ${cmd} -n 2 foo"
   echo "   ${cmd} -np 2 foo foo_arg1 foo_arg2"
   echo "   ${cmd} -v"
   echo "   ${cmd} --help"
@@ -274,7 +276,8 @@ elif [[ "${1}" == -np || "${1}" == -n ]]; then
       exit "${return_code}"
     fi
   else
-    echo "You must pass \"-np\", \"<number_of_images>\", \"/path/to/coarray_Fortran_program\" as the first 3 arguments to ${cmd}."
-    exit 1
+    usage
   fi
+else
+  usage
 fi


### PR DESCRIPTION
<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Fixed #717 

## Rationale for changes ##

`cafrun` exited quietly when no number of images was specified, e.g., `cafrun ./a.out`.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
