### PR TITLE
Use dynamic symbol resolution for libmpi_caf on macOS

### DIFF
--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -80,6 +80,14 @@ set_target_properties ( caf_mpi
 #  VERSION ${PROJECT_VERSION}
 )
 
+# Unfortunately caf_mpi.c calls a function directly from libgfortran and this can be resolved later
+if(APPLE)
+  set_target_properties ( caf_mpi
+    PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup"
+  )
+endif()
+
 # Create a symlink in the include dir
 if(UNIX)
   add_custom_command(TARGET caf_mpi


### PR DESCRIPTION
I'd like to get the CI system back up to parity with the old Travis-CI system. If I have time I'll add this to this PR, otherwise I'll change this from a draft to a real PR and just commit what's here.

Unfortunately mpi_caf.c now calls into libgfortran for the random seed
functionality.
It would be nice to avoid this if possible, but it's stateful so I
doubt that it would be possible.
Any code that links to the library should be Fortran code and/or pull in libgfortran.

<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

On macOS link the caf_mpi shared dylib so that symbols from libgfortran that are unresolved when building the library can be dynamically resolved at runtime (or when the executable is linked, perhaps?).

## Rationale for changes ##

Recent changes broke OpenCoarrays on macOS. These changes were made to handle RNG seeding behavior and support make calls directly into libgfortran. Since this is stateful I doubt there is any way to avoid this, but if there is we should consider it. By default, macOS doesn't like unresolved symbols when creating shared/dynamic .dylib libraries, but you can tell the macOS linker to ignore undefined symbols and resolve them dynamically (at runtime or link time of the executable I presume). On linux the linker doesn't seem to care about creating shared libraries with undefined symbols which is why this issue didn't affect linux.

## Additional info and certifications ##

This pull request (PR) is a:

- [X] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [X] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
