### PR TITLE
CMake: fix -Wint-conversion warning (error if clang is used as MPIC_C)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,7 +422,7 @@ int main(int argc, char** argv) {
   char processor_name[MPI_MAX_PROCESSOR_NAME];
   int name_len;
   MPI_Get_processor_name(processor_name, &name_len);
-  printf('Hello world from processor %s, rank %d out of %d processors',
+  printf(\"Hello world from processor %s, rank %d out of %d processors\",
          processor_name, world_rank, world_size);
   MPI_Finalize();
 }"


### PR DESCRIPTION
Using of single quotes for `printf` argument within MPI_C check of CMakeLists.txt results in warning of conversion to int. The single quotes is used for char/int but not for char* type where the double quotes should be used.

If clang is used as MPI_C instead of gcc the configuration is failed with error:
`incompatible integer to pointer conversion passing 'int' to parameter of type 'const char *' [-Wint-conversion]`

(refer Gentoo [guru overlay] issue:[https://bugs.gentoo.org/888009]( https://bugs.gentoo.org/888009))

<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Fix `-Wint-conversion` warning that results in CMake configuration error if `clang` is used as `MPI_C` compiler.

## Rationale for changes ##

The presence of downstream issue (Gentoo Linux [guru overlay]): https://bugs.gentoo.org/888009

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [ ] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
