### PR TITLE
Fix sending data to self.

### DIFF
--- a/src/tests/unit/send-get/send_convert_nums.f90
+++ b/src/tests/unit/send-get/send_convert_nums.f90
@@ -364,7 +364,7 @@ program send_convert_nums
         & call print_and_register( 'send strided int kind=1 to kind=1 self failed.')
 
       co_int_k4 = -1
-      co_int_k4(::2)[1] = int_k4
+      co_int_k4(::2)[1] = int_k4(1:3)
       print *, co_int_k4
       if (any(co_int_k4 /= [int_k4(1), -1, int_k4(2), -1, int_k4(3)])) &
         call print_and_register( 'send strided int kind=4 to kind=4 self failed.')


### PR DESCRIPTION
<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Correctly copy data when sending to this_image.

## Rationale for changes ##

Sending data to this_image() lead to doing a memmove even when that was unsuitable, because size, rank, type, a.s.o. did not match. This patch directs all data sends to the convert routine, which does scalar to array and type/kind conversion correctly.

## Additional info and certifications ##

This pull request (PR) is a:

- [x] Bug fix
- [ ] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [x] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
