### PR TITLE
Add clang-formating for c sources and headers.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+#
+
+---
+BasedOnStyle: Microsoft
+Language: Cpp
+
+AlignAfterOpenBracket: Align
+AlignOperands: Align
+AlwaysBreakAfterReturnType: TopLevel
+BraceWrapping:
+  AfterCaseLabel: true
+BreakBeforeBinaryOperators: true
+ColumnLimit: 80
+IndentCaseBlocks: true
+IndentCaseLabels: true
+IndentWidth: 2
+PointerAlignment: Right

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,6 +629,19 @@ function(check_script_style script_full_path)
   endif()
 endfunction()
 
+#------------------------------------------------------------
+# Setup clang-format if present for testing/linting c sources
+#------------------------------------------------------------
+find_program(CLANGFORMAT_EXE clang-format
+  DOC "Path to clang-format executable for linting c sources/headers"
+  )
+if (CAF_RUN_DEVELOPER_TESTS OR $ENV{OPENCOARRAYS_DEVELOPER})
+  if(NOT CLANGFORMAT_EXE)
+    message( AUTHOR_WARNING "OpenCoarrays developers should install clang-format to test/lint all C sources and headers.
+    See https://releases.llvm.org/download.html for info on obtaining clang-format as part of clang.")
+  endif()
+endif()
+
 #------------------------------------------------------------------------------
 # Add custom properties on targets for controling number of images during tests
 #------------------------------------------------------------------------------

--- a/developer-scripts/git-hooks/pre-commit
+++ b/developer-scripts/git-hooks/pre-commit
@@ -93,6 +93,14 @@ for f in $(git diff-index --name-status --cached $against | grep -v ^D | cut -c3
 	    status=1
 	fi
     fi
+    if [[ "$f" =~ ([.](h|c))$ ]] ; then
+	if ! clang-format --dry-run --Werror "$f" >&/dev/null; then
+	    echo "Format violation of file: $f"
+            echo "Use clang-format to fix it."
+            echo ""
+            status=1
+        fi
+    fi
 done
 
 # If there are whitespace errors, print the offending file names and fail.

--- a/src/application-binary-interface/libcaf-gfortran-descriptor.h
+++ b/src/application-binary-interface/libcaf-gfortran-descriptor.h
@@ -33,8 +33,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 /* GNU Fortran's array descriptor.  Keep in sync with libgfortran.h.  */
 
 enum
-{ BT_UNKNOWN = 0, BT_INTEGER, BT_LOGICAL, BT_REAL, BT_COMPLEX,
-  BT_DERIVED, BT_CHARACTER, BT_CLASS, BT_PROCEDURE, BT_HOLLERITH, BT_VOID,
+{
+  BT_UNKNOWN = 0,
+  BT_INTEGER,
+  BT_LOGICAL,
+  BT_REAL,
+  BT_COMPLEX,
+  BT_DERIVED,
+  BT_CHARACTER,
+  BT_CLASS,
+  BT_PROCEDURE,
+  BT_HOLLERITH,
+  BT_VOID,
   BT_ASSUMED
 };
 
@@ -43,22 +53,21 @@ typedef struct descriptor_dimension
   ptrdiff_t _stride;
   ptrdiff_t lower_bound;
   ptrdiff_t _ubound;
-}
-descriptor_dimension;
+} descriptor_dimension;
 
 #ifdef GCC_GE_8
-  typedef struct dtype_type
-  {
-    size_t elem_len;
-    int version;
-    signed char rank;
-    signed char type;
-    signed short attribute;
-  }
-  dtype_type;
+typedef struct dtype_type
+{
+  size_t elem_len;
+  int version;
+  signed char rank;
+  signed char type;
+  signed short attribute;
+} dtype_type;
 #endif
 
-typedef struct gfc_descriptor_t {
+typedef struct gfc_descriptor_t
+{
   void *base_addr;
   size_t offset;
 #ifdef GCC_GE_8
@@ -81,8 +90,10 @@ typedef struct gfc_descriptor_t {
 #define GFC_DESCRIPTOR_RANK(desc) (desc)->dtype.rank
 #define GFC_DESCRIPTOR_TYPE(desc) (desc)->dtype.type
 #define GFC_DESCRIPTOR_SIZE(desc) (desc)->dtype.elem_len
-#define GFC_DTYPE_TYPE_SIZE(desc) (( ((desc)->dtype.type << GFC_DTYPE_TYPE_SHIFT) \
-    | ((desc)->dtype.elem_len << GFC_DTYPE_SIZE_SHIFT) ) & GFC_DTYPE_TYPE_SIZE_MASK)
+#define GFC_DTYPE_TYPE_SIZE(desc)                                              \
+  ((((desc)->dtype.type << GFC_DTYPE_TYPE_SHIFT)                               \
+    | ((desc)->dtype.elem_len << GFC_DTYPE_SIZE_SHIFT))                        \
+   & GFC_DTYPE_TYPE_SIZE_MASK)
 
 #else
 
@@ -93,87 +104,102 @@ typedef struct gfc_descriptor_t {
 #define GFC_DTYPE_SIZE_SHIFT 6
 
 #define GFC_DESCRIPTOR_RANK(desc) ((desc)->dtype & GFC_DTYPE_RANK_MASK)
-#define GFC_DESCRIPTOR_TYPE(desc) (((desc)->dtype & GFC_DTYPE_TYPE_MASK) \
-                                   >> GFC_DTYPE_TYPE_SHIFT)
+#define GFC_DESCRIPTOR_TYPE(desc)                                              \
+  (((desc)->dtype & GFC_DTYPE_TYPE_MASK) >> GFC_DTYPE_TYPE_SHIFT)
 #define GFC_DESCRIPTOR_SIZE(desc) ((desc)->dtype >> GFC_DTYPE_SIZE_SHIFT)
 #define GFC_DTYPE_TYPE_SIZE(desc) ((desc)->dtype & GFC_DTYPE_TYPE_SIZE_MASK)
 
 #endif
 
-#define GFC_DTYPE_SIZE_MASK \
-  ( ~((ptrdiff_t)(1 << GFC_DTYPE_SIZE_SHIFT) - 1)) // least significant bits to 0
+#define GFC_DTYPE_SIZE_MASK                                                    \
+  (~((ptrdiff_t)(1 << GFC_DTYPE_SIZE_SHIFT) - 1)) // least significant bits to 0
 #define GFC_DTYPE_TYPE_SIZE_MASK (GFC_DTYPE_SIZE_MASK | GFC_DTYPE_TYPE_MASK)
 
-#define GFC_DTYPE_INTEGER_1 ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_INTEGER_1                                                    \
+  ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(int8_t) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_INTEGER_2 ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_INTEGER_2                                                    \
+  ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(int16_t) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_INTEGER_4 ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_INTEGER_4                                                    \
+  ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(int32_t) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_INTEGER_8 ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_INTEGER_8                                                    \
+  ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(int64_t) << GFC_DTYPE_SIZE_SHIFT))
 #if HAVE_INT128_T
-#define GFC_DTYPE_INTEGER_16 ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_INTEGER_16                                                   \
+  ((BT_INTEGER << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(__int128_t) << GFC_DTYPE_SIZE_SHIFT))
 #endif
 
-#define GFC_DTYPE_LOGICAL_4 ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT) \
-   | (sizeof(int) << GFC_DTYPE_SIZE_SHIFT))
+#define GFC_DTYPE_LOGICAL_4                                                    \
+  ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT) | (sizeof(int) << GFC_DTYPE_SIZE_SHIFT))
 
 #if 0
-#define GFC_DTYPE_LOGICAL_1 ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_LOGICAL_1                                                    \
+  ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(GFC_LOGICAL_1) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_LOGICAL_2 ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_LOGICAL_2                                                    \
+  ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(GFC_LOGICAL_2) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_LOGICAL_8 ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_LOGICAL_8                                                    \
+  ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(double) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_LOGICAL_16 ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT)\
+#define GFC_DTYPE_LOGICAL_16                                                   \
+  ((BT_LOGICAL << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(GFC_LOGICAL_16) << GFC_DTYPE_SIZE_SHIFT))
 #endif
 
-#define GFC_DTYPE_REAL_4 ((BT_REAL << GFC_DTYPE_TYPE_SHIFT) \
-   | (sizeof(float) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_REAL_8 ((BT_REAL << GFC_DTYPE_TYPE_SHIFT) \
-   | (sizeof(double) << GFC_DTYPE_SIZE_SHIFT))
+#define GFC_DTYPE_REAL_4                                                       \
+  ((BT_REAL << GFC_DTYPE_TYPE_SHIFT) | (sizeof(float) << GFC_DTYPE_SIZE_SHIFT))
+#define GFC_DTYPE_REAL_8                                                       \
+  ((BT_REAL << GFC_DTYPE_TYPE_SHIFT) | (sizeof(double) << GFC_DTYPE_SIZE_SHIFT))
 #if 0
 #ifdef HAVE_GFC_REAL_10
-#define GFC_DTYPE_REAL_10  ((BT_REAL << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_REAL_10                                                      \
+  ((BT_REAL << GFC_DTYPE_TYPE_SHIFT)                                           \
    | (sizeof(GFC_REAL_10) << GFC_DTYPE_SIZE_SHIFT))
 #endif
 #ifdef HAVE_GFC_REAL_16
-#define GFC_DTYPE_REAL_16 ((BT_REAL << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_REAL_16                                                      \
+  ((BT_REAL << GFC_DTYPE_TYPE_SHIFT)                                           \
    | (sizeof(GFC_REAL_16) << GFC_DTYPE_SIZE_SHIFT))
 #endif
 #endif
 
-#define GFC_DTYPE_COMPLEX_4 ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_COMPLEX_4                                                    \
+  ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(_Complex float) << GFC_DTYPE_SIZE_SHIFT))
-#define GFC_DTYPE_COMPLEX_8 ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_COMPLEX_8                                                    \
+  ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(_Complex double) << GFC_DTYPE_SIZE_SHIFT))
 #if 0
 #ifdef HAVE_GFC_COMPLEX_10
-#define GFC_DTYPE_COMPLEX_10 ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_COMPLEX_10                                                   \
+  ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(GFC_COMPLEX_10) << GFC_DTYPE_SIZE_SHIFT))
 #endif
 #ifdef HAVE_GFC_COMPLEX_16
-#define GFC_DTYPE_COMPLEX_16 ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_COMPLEX_16                                                   \
+  ((BT_COMPLEX << GFC_DTYPE_TYPE_SHIFT)                                        \
    | (sizeof(GFC_COMPLEX_16) << GFC_DTYPE_SIZE_SHIFT))
 #endif
 #endif
 
-/* FIXME: Hardwiring these values to what the mpi_caf.c macro GFC_DTYPE_TYPE_SIZE(desc)
-    receives in the dtype component its gf_descriptor_t argument for character(kind=c_char)
-    and logical(kind=c_bool) data:
+/* FIXME: Hardwiring these values to what the mpi_caf.c macro
+   GFC_DTYPE_TYPE_SIZE(desc) receives in the dtype component its gf_descriptor_t
+   argument for character(kind=c_char) and logical(kind=c_bool) data:
 */
 
 #ifdef GCC_GE_8
 
-#define GFC_DTYPE_CHARACTER ((BT_CHARACTER << GFC_DTYPE_TYPE_SHIFT) \
+#define GFC_DTYPE_CHARACTER                                                    \
+  ((BT_CHARACTER << GFC_DTYPE_TYPE_SHIFT)                                      \
    | (sizeof(char) << GFC_DTYPE_SIZE_SHIFT))
 
 #else
 #define GFC_DTYPE_CHARACTER 48
 #endif
 
-
-#endif  /* LIBCAF_GFORTRAN_DESCRIPTOR_H.  */
+#endif /* LIBCAF_GFORTRAN_DESCRIPTOR_H.  */

--- a/src/application-binary-interface/libcaf.h
+++ b/src/application-binary-interface/libcaf.h
@@ -28,11 +28,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #ifndef LIBCAF_H
 #define LIBCAF_H
 
-#include <stddef.h>     /* For size_t.  */
 #include <stdbool.h>
+#include <stddef.h> /* For size_t.  */
 
-#include "libcaf-version-def.h"
 #include "libcaf-gfortran-descriptor.h"
+#include "libcaf-version-def.h"
 
 #ifdef HAVE_MPI
 #include <mpi.h>
@@ -40,34 +40,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 
 #ifndef __GNUC__
 #define __attribute__(x)
-#define likely(x)       (x)
-#define unlikely(x)     (x)
+#define likely(x) (x)
+#define unlikely(x) (x)
 #else
-#define likely(x)       __builtin_expect(!!(x), 1)
-#define unlikely(x)     __builtin_expect(!!(x), 0)
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
 
 #ifdef PREFIX_NAME
-#define PREFIX3(X,Y) X ## Y
-#define PREFIX2(X,Y) PREFIX3(X,Y)
-#define PREFIX(X) PREFIX2(PREFIX_NAME,X)
+#define PREFIX3(X, Y) X##Y
+#define PREFIX2(X, Y) PREFIX3(X, Y)
+#define PREFIX(X) PREFIX2(PREFIX_NAME, X)
 #else
 #define PREFIX(X) X
 #endif
 
-
 /* Definitions of the Fortran 2008 standard; need to kept in sync with
    ISO_FORTRAN_ENV, cf. libgfortran.h.  */
-#define STAT_UNLOCKED           0
-#define STAT_LOCKED             1
+#define STAT_UNLOCKED 0
+#define STAT_LOCKED 1
 #define STAT_LOCKED_OTHER_IMAGE 2
-#define STAT_DUP_SYNC_IMAGES    3
-#define STAT_STOPPED_IMAGE      6000
-#define STAT_FAILED_IMAGE       6001
+#define STAT_DUP_SYNC_IMAGES 3
+#define STAT_STOPPED_IMAGE 6000
+#define STAT_FAILED_IMAGE 6001
 
 /* Describes what type of array we are registerring. Keep in sync with
    gcc/fortran/trans.h.  */
-typedef enum caf_register_t {
+typedef enum caf_register_t
+{
   CAF_REGTYPE_COARRAY_STATIC,
   CAF_REGTYPE_COARRAY_ALLOC,
   CAF_REGTYPE_LOCK_STATIC,
@@ -77,54 +77,57 @@ typedef enum caf_register_t {
   CAF_REGTYPE_EVENT_ALLOC,
   CAF_REGTYPE_COARRAY_ALLOC_REGISTER_ONLY,
   CAF_REGTYPE_COARRAY_ALLOC_ALLOCATE_ONLY
-}
-caf_register_t;
+} caf_register_t;
 
 /* Describes the action to take on _caf_deregister. Keep in sync with
    gcc/fortran/trans.h.  */
-typedef enum caf_deregister_t {
+typedef enum caf_deregister_t
+{
   CAF_DEREGTYPE_COARRAY_DEREGISTER,
   CAF_DEREGTYPE_COARRAY_DEALLOCATE_ONLY
-}
-caf_deregister_t;
+} caf_deregister_t;
 
-typedef void* caf_token_t;
+typedef void *caf_token_t;
 /** Add a dummy type representing teams in coarrays. */
 
-typedef void * caf_team_t;
+typedef void *caf_team_t;
 
-typedef struct caf_teams_list {
+typedef struct caf_teams_list
+{
   caf_team_t team;
   int team_id;
   struct caf_teams_list *prev;
 } caf_teams_list;
 
-typedef struct caf_used_teams_list {
+typedef struct caf_used_teams_list
+{
   struct caf_teams_list *team_list_elem;
   struct caf_used_teams_list *prev;
 } caf_used_teams_list;
 
-
 /* When there is a vector subscript in this dimension, nvec == 0, otherwise,
    lower_bound, upper_bound, stride contains the bounds relative to the declared
    bounds; kind denotes the integer kind of the elements of vector[].  */
-typedef struct caf_vector_t {
+typedef struct caf_vector_t
+{
   size_t nvec;
   union {
-    struct {
+    struct
+    {
       void *vector;
       int kind;
     } v;
-    struct {
+    struct
+    {
       ptrdiff_t lower_bound, upper_bound, stride;
     } triplet;
   } u;
 } caf_vector_t;
 
-
 #ifdef GCC_GE_7
 /* Keep in sync with gcc/libgfortran/caf/libcaf.h.  */
-typedef enum caf_ref_type_t {
+typedef enum caf_ref_type_t
+{
   /* Reference a component of a derived type, either regular one or an
      allocatable or pointer type.  For regular ones idx in caf_reference_t is
      set to -1.  */
@@ -136,7 +139,8 @@ typedef enum caf_ref_type_t {
 } caf_ref_type_t;
 
 /* Keep in sync with gcc/libgfortran/caf/libcaf.h.  */
-typedef enum caf_array_ref_t {
+typedef enum caf_array_ref_t
+{
   /* No array ref.  This terminates the array ref.  */
   CAF_ARR_REF_NONE = 0,
   /* Reference array elements given by a vector.  Only for this mode
@@ -158,7 +162,8 @@ typedef enum caf_array_ref_t {
 
 /* References to remote components of a derived type.
    Keep in sync with gcc/libgfortran/caf/libcaf.h.  */
-typedef struct caf_reference_t {
+typedef struct caf_reference_t
+{
   /* A pointer to the next ref or NULL.  */
   struct caf_reference_t *next;
   /* The type of the reference.  */
@@ -169,14 +174,16 @@ typedef struct caf_reference_t {
      For component refs this gives just the size of the element referenced.  */
   size_t item_size;
   union {
-    struct {
+    struct
+    {
       /* The offset (in bytes) of the component in the derived type.  */
       ptrdiff_t offset;
       /* The offset (in bytes) to the caf_token associated with this
          component.  NULL, when not allocatable/pointer ref.  */
       ptrdiff_t caf_token_offset;
     } c;
-    struct {
+    struct
+    {
       /* The mode of the array ref.  See CAF_ARR_REF_*.  */
       /* caf_array_ref_t, replaced by unsigend char to allow specification in
          fortran FE.  */
@@ -185,11 +192,13 @@ typedef struct caf_reference_t {
       int static_array_type;
       /* Subscript refs (s) or vector refs (v).  */
       union {
-        struct {
+        struct
+        {
           /* The start and end boundary of the ref and the stride.  */
           ptrdiff_t start, end, stride;
         } s;
-        struct {
+        struct
+        {
           /* nvec entries of kind giving the elements to reference.  */
           void *vector;
           /* The number of entries in vector.  */
@@ -203,13 +212,12 @@ typedef struct caf_reference_t {
 } caf_reference_t;
 #endif
 
-
 /* The following defines give the bits in the opr_flags argument to CO_REDUCE.
   Keep in sync with the libgfortran.h file of gcc/fortran.  */
-#define GFC_CAF_BYREF      (1<<0)
-#define GFC_CAF_HIDDENLEN  (1<<1)
-#define GFC_CAF_ARG_VALUE  (1<<2)
-#define GFC_CAF_ARG_DESC   (1<<3)
+#define GFC_CAF_BYREF (1 << 0)
+#define GFC_CAF_HIDDENLEN (1 << 1)
+#define GFC_CAF_ARG_VALUE (1 << 2)
+#define GFC_CAF_ARG_DESC (1 << 3)
 
 /* The type to use for string lengths.  */
 #ifdef GCC_GE_8
@@ -222,120 +230,119 @@ typedef int charlen_t;
 
 /* Common auxiliary functions: caf_auxiliary.c.  */
 
-bool PREFIX (is_contiguous) (gfc_descriptor_t *);
+bool PREFIX(is_contiguous)(gfc_descriptor_t *);
 
 /* Header for the specific implementation.  */
 
-void PREFIX (init) (int *, char ***);
-void PREFIX (finalize) (void);
+void PREFIX(init)(int *, char ***);
+void PREFIX(finalize)(void);
 
-int PREFIX (this_image) (int);
-int PREFIX (num_images) (int, int);
+int PREFIX(this_image)(int);
+int PREFIX(num_images)(int, int);
 
 #ifdef GCC_GE_7
-void PREFIX (register) (size_t, caf_register_t, caf_token_t *,
-                        gfc_descriptor_t *, int *, char *, charlen_t);
-void PREFIX (deregister) (caf_token_t *, int, int *, char *, charlen_t);
+void PREFIX(register)(size_t, caf_register_t, caf_token_t *, gfc_descriptor_t *,
+                      int *, char *, charlen_t);
+void PREFIX(deregister)(caf_token_t *, int, int *, char *, charlen_t);
 #else
-void * PREFIX (register) (size_t, caf_register_t, caf_token_t *, int *, char *,
-                          int);
-void PREFIX (deregister) (caf_token_t *, int *, char *, int);
+void *PREFIX(register)(size_t, caf_register_t, caf_token_t *, int *, char *,
+                       int);
+void PREFIX(deregister)(caf_token_t *, int *, char *, int);
 #endif
 
-void PREFIX (caf_get) (caf_token_t, size_t, int, gfc_descriptor_t *,
-                       caf_vector_t *, gfc_descriptor_t *, int, int, bool,
-                       int *);
-void PREFIX (caf_send) (caf_token_t, size_t, int, gfc_descriptor_t *,
-                        caf_vector_t *, gfc_descriptor_t *, int, int, bool,
-                        int *);
+void PREFIX(caf_get)(caf_token_t, size_t, int, gfc_descriptor_t *,
+                     caf_vector_t *, gfc_descriptor_t *, int, int, bool, int *);
+void PREFIX(caf_send)(caf_token_t, size_t, int, gfc_descriptor_t *,
+                      caf_vector_t *, gfc_descriptor_t *, int, int, bool,
+                      int *);
 
-void PREFIX (caf_sendget) (caf_token_t, size_t, int, gfc_descriptor_t *,
-                           caf_vector_t *, caf_token_t, size_t, int,
-                           gfc_descriptor_t *, caf_vector_t *, int, int, bool,
-                           int *);
+void PREFIX(caf_sendget)(caf_token_t, size_t, int, gfc_descriptor_t *,
+                         caf_vector_t *, caf_token_t, size_t, int,
+                         gfc_descriptor_t *, caf_vector_t *, int, int, bool,
+                         int *);
 
 #ifdef GCC_GE_8
-void PREFIX(get_by_ref) (caf_token_t, int,
-                         gfc_descriptor_t *dst, caf_reference_t *refs,
+void PREFIX(get_by_ref)(caf_token_t, int, gfc_descriptor_t *dst,
+                        caf_reference_t *refs, int dst_kind, int src_kind,
+                        bool may_require_tmp, bool dst_reallocatable, int *stat,
+                        int src_type);
+void PREFIX(send_by_ref)(caf_token_t token, int image_index,
+                         gfc_descriptor_t *src, caf_reference_t *refs,
                          int dst_kind, int src_kind, bool may_require_tmp,
-                         bool dst_reallocatable, int *stat, int src_type);
-void PREFIX(send_by_ref) (caf_token_t token, int image_index,
-                          gfc_descriptor_t *src, caf_reference_t *refs,
-                          int dst_kind, int src_kind, bool may_require_tmp,
-                          bool dst_reallocatable, int *stat, int dst_type);
-void PREFIX(sendget_by_ref) (caf_token_t dst_token, int dst_image_index,
-                             caf_reference_t *dst_refs, caf_token_t src_token,
-                             int src_image_index, caf_reference_t *src_refs,
-                             int dst_kind, int src_kind, bool may_require_tmp,
-                             int *dst_stat, int *src_stat, int dst_type,
-                             int src_type);
+                         bool dst_reallocatable, int *stat, int dst_type);
+void PREFIX(sendget_by_ref)(caf_token_t dst_token, int dst_image_index,
+                            caf_reference_t *dst_refs, caf_token_t src_token,
+                            int src_image_index, caf_reference_t *src_refs,
+                            int dst_kind, int src_kind, bool may_require_tmp,
+                            int *dst_stat, int *src_stat, int dst_type,
+                            int src_type);
 #elif defined(GCC_GE_7)
-void PREFIX(get_by_ref) (caf_token_t, int,
-                         gfc_descriptor_t *dst, caf_reference_t *refs,
+void PREFIX(get_by_ref)(caf_token_t, int, gfc_descriptor_t *dst,
+                        caf_reference_t *refs, int dst_kind, int src_kind,
+                        bool may_require_tmp, bool dst_reallocatable,
+                        int *stat);
+void PREFIX(send_by_ref)(caf_token_t token, int image_index,
+                         gfc_descriptor_t *src, caf_reference_t *refs,
                          int dst_kind, int src_kind, bool may_require_tmp,
                          bool dst_reallocatable, int *stat);
-void PREFIX(send_by_ref) (caf_token_t token, int image_index,
-                          gfc_descriptor_t *src, caf_reference_t *refs,
-                          int dst_kind, int src_kind, bool may_require_tmp,
-                          bool dst_reallocatable, int *stat);
-void PREFIX(sendget_by_ref) (caf_token_t dst_token, int dst_image_index,
-                             caf_reference_t *dst_refs, caf_token_t src_token,
-                             int src_image_index, caf_reference_t *src_refs,
-                             int dst_kind, int src_kind, bool may_require_tmp,
-                             int *dst_stat, int *src_stat);
+void PREFIX(sendget_by_ref)(caf_token_t dst_token, int dst_image_index,
+                            caf_reference_t *dst_refs, caf_token_t src_token,
+                            int src_image_index, caf_reference_t *src_refs,
+                            int dst_kind, int src_kind, bool may_require_tmp,
+                            int *dst_stat, int *src_stat);
 #endif
 #ifdef GCC_GE_7
-int PREFIX(is_present) (caf_token_t, int, caf_reference_t *refs);
+int PREFIX(is_present)(caf_token_t, int, caf_reference_t *refs);
 #endif
 
-void PREFIX (co_broadcast) (gfc_descriptor_t *, int, int *, char *, charlen_t);
-void PREFIX (co_max) (gfc_descriptor_t *, int, int *, char *, int, charlen_t);
-void PREFIX (co_min) (gfc_descriptor_t *, int, int *, char *, int, charlen_t);
-void PREFIX (co_reduce) (gfc_descriptor_t *, void *(*opr) (void *, void *),
-                         int, int, int *, char *, int , charlen_t);
-void PREFIX (co_sum) (gfc_descriptor_t *, int, int *, char *, charlen_t);
+void PREFIX(co_broadcast)(gfc_descriptor_t *, int, int *, char *, charlen_t);
+void PREFIX(co_max)(gfc_descriptor_t *, int, int *, char *, int, charlen_t);
+void PREFIX(co_min)(gfc_descriptor_t *, int, int *, char *, int, charlen_t);
+void PREFIX(co_reduce)(gfc_descriptor_t *, void *(*opr)(void *, void *), int,
+                       int, int *, char *, int, charlen_t);
+void PREFIX(co_sum)(gfc_descriptor_t *, int, int *, char *, charlen_t);
 
-void PREFIX (sync_all) (int *, char *, charlen_t);
-void PREFIX (sync_images) (int, int[], int *, char *, charlen_t);
-void PREFIX (sync_memory) (int *, char *, charlen_t);
+void PREFIX(sync_all)(int *, char *, charlen_t);
+void PREFIX(sync_images)(int, int[], int *, char *, charlen_t);
+void PREFIX(sync_memory)(int *, char *, charlen_t);
 
-void PREFIX (stop_str) (const char *, charlen_t QUIETARG)
-                        __attribute__ ((noreturn));
-void PREFIX (stop) (int QUIETARG) __attribute__ ((noreturn));
-void PREFIX (error_stop_str) (const char *, charlen_t QUIETARG)
-                              __attribute__ ((noreturn));
-void PREFIX (error_stop) (int QUIETARG) __attribute__ ((noreturn));
+void PREFIX(stop_str)(const char *, charlen_t QUIETARG)
+    __attribute__((noreturn));
+void PREFIX(stop)(int QUIETARG) __attribute__((noreturn));
+void PREFIX(error_stop_str)(const char *, charlen_t QUIETARG)
+    __attribute__((noreturn));
+void PREFIX(error_stop)(int QUIETARG) __attribute__((noreturn));
 
-void PREFIX (fail_image) (void) __attribute__ ((noreturn));
+void PREFIX(fail_image)(void) __attribute__((noreturn));
 
-void PREFIX (form_team) (int, caf_team_t *, int);
-void PREFIX (change_team) (caf_team_t *, int);
-void PREFIX (end_team) (caf_team_t *);
-void PREFIX (sync_team) (caf_team_t *, int);
-int PREFIX (team_number) (caf_team_t *);
+void PREFIX(form_team)(int, caf_team_t *, int);
+void PREFIX(change_team)(caf_team_t *, int);
+void PREFIX(end_team)(caf_team_t *);
+void PREFIX(sync_team)(caf_team_t *, int);
+int PREFIX(team_number)(caf_team_t *);
 
-int PREFIX (image_status) (int);
-void PREFIX (failed_images) (gfc_descriptor_t *, int, int *);
-void PREFIX (stopped_images) (gfc_descriptor_t *, int, int *);
+int PREFIX(image_status)(int);
+void PREFIX(failed_images)(gfc_descriptor_t *, int, int *);
+void PREFIX(stopped_images)(gfc_descriptor_t *, int, int *);
 
-void PREFIX (atomic_define) (caf_token_t, size_t, int, void *, int *, int, int);
-void PREFIX (atomic_ref) (caf_token_t, size_t, int, void *, int *, int, int);
-void PREFIX (atomic_cas) (caf_token_t, size_t, int, void *, void *,
-                          void *, int *, int, int);
-void PREFIX (atomic_op) (int, caf_token_t, size_t, int, void *, void *,
-                         int *, int, int);
+void PREFIX(atomic_define)(caf_token_t, size_t, int, void *, int *, int, int);
+void PREFIX(atomic_ref)(caf_token_t, size_t, int, void *, int *, int, int);
+void PREFIX(atomic_cas)(caf_token_t, size_t, int, void *, void *, void *, int *,
+                        int, int);
+void PREFIX(atomic_op)(int, caf_token_t, size_t, int, void *, void *, int *,
+                       int, int);
 
-void PREFIX (lock) (caf_token_t, size_t, int, int *, int *, char *, charlen_t);
-void PREFIX (unlock) (caf_token_t, size_t, int, int *, char *, charlen_t);
-void PREFIX (event_post) (caf_token_t, size_t, int, int *, char *, charlen_t);
-void PREFIX (event_wait) (caf_token_t, size_t, int, int *, char *, charlen_t);
-void PREFIX (event_query) (caf_token_t, size_t, int, int *, int *);
+void PREFIX(lock)(caf_token_t, size_t, int, int *, int *, char *, charlen_t);
+void PREFIX(unlock)(caf_token_t, size_t, int, int *, char *, charlen_t);
+void PREFIX(event_post)(caf_token_t, size_t, int, int *, char *, charlen_t);
+void PREFIX(event_wait)(caf_token_t, size_t, int, int *, char *, charlen_t);
+void PREFIX(event_query)(caf_token_t, size_t, int, int *, int *);
 
-void PREFIX (random_init) (bool, bool);
+void PREFIX(random_init)(bool, bool);
 
 /* Language extension */
 #ifdef HAVE_MPI
-MPI_Fint PREFIX (get_communicator) (caf_team_t *);
+MPI_Fint PREFIX(get_communicator)(caf_team_t *);
 #endif
 
-#endif  /* LIBCAF_H  */
+#endif /* LIBCAF_H  */


### PR DESCRIPTION
<!-- Please fill out the pull request template included below. Failure -->
<!-- to do so may result in immediate closure of your pull request! -->

<!-- Fill out all portions of this template that apply. Please delete -->
<!-- any unnecessary sections. -->

<!-- PRO TIP! Submit the pull request *before* you check any -->
<!-- checkboxes. Then, use the gui/web interface to check the -->
<!-- checkboxes! -->

[links]:#
[contributing guidelines]: https://github.com/sourceryinstitute/OpenCoarrays/blob/master/CONTRIBUTING.md
[issue]: https://github.com/sourceryinstitute/OpenCoarrays/issues
[coverage]: https://img.shields.io/codecov/c/github/sourceryinstitute/OpenCoarrays/master.svg?style=flat-square

|  coverage on master         |
|:---------------------------:|
| ![Codecov branch][coverage] |

## Summary of changes ##

Unify formatting of C sources utilizing a tool available on all platforms.

## Rationale for changes ##

Editing the sources always lead to indentation and formatting getting ugly or I had to manually fix the formatting my IDE did. I therefore opted to use a tool (clang-format) that is widely available and can be configured to have the code look very similar to the previous version. Furthermore does is support partial formatting in IDEs, i.e. only code that is edited is reformatted.

## Additional info and certifications ##

This pull request (PR) is a:

- [ ] Bug fix
- [x] Feature addition
- [ ] Other, Please describe:

### I certify that ###

- [ ] I certify that:
  - I have reviewed and followed the [contributing guidelines]
  - I will wait at least 24 hours before self-approving the PR to give another
    OpenCoarrays developer a chance to review my proposed code
  - I have not introduced errant white space (no trailing white space or white space errors may
    be introduced)
  - I have added an explanation of what these changes do and why they should be included
  - I have checked to ensure there aren't other open [Pull Requests] for the same change
  - I have you written new tests for these changes
  - I have successfully tested these changes locally
  - I have commented any non-trivial, non-obvious code changes
  - The commits are logically atomic, self consistent and coherent
  - The [commit messages] follow [best practices]
  - Test coverage is maintained or increased after this is merged


## Code coverage data

![coverage on master](https://codecov.io/gh/sourceryinstitute/OpenCoarrays/branch/master/graphs/commits.svg)


[links]: #
[best practices]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[commit messages]: https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message
[Pull Requests]: https://github.com/sourceryinstitue/OpenCoarrays/pulls
